### PR TITLE
Guest email issue on placeOrder

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/hosted.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted.js
@@ -18,9 +18,10 @@ define(
         'CheckoutCom_Magento2/js/view/payment/adapter',
         'Magento_Checkout/js/model/quote',
         'mage/url',
-        'Magento_Checkout/js/model/payment/additional-validators'
+        'Magento_Checkout/js/model/payment/additional-validators',
+        'Magento_Checkout/js/checkout-data'
     ],
-    function ($, Component, VaultEnabler, CheckoutCom, quote, url, additionalValidators) {
+    function ($, Component, VaultEnabler, CheckoutCom, quote, url, additionalValidators, checkoutData) {
         'use strict';
 
         return Component.extend({
@@ -98,7 +99,10 @@ define(
              */
             saveSessionData: function() {
                 // Prepare the session data
-                var sessionData = {saveShopperCard: $('#checkout_com_enable_vault').is(":checked")};
+                var sessionData = {
+                    saveShopperCard: $('#checkout_com_enable_vault').is(":checked"),
+                    customerEmail: checkoutData.getValidatedEmailValue()
+                };
 
                 // Send the session data to be saved
                 $.ajax({


### PR DESCRIPTION
Environment set
```
Server version: Apache/2.4.18 (Ubuntu)
PHP 7.0.15-0ubuntu0.16.04.4
magento/product-enterprise-edition: 2.1.9
```

Module configuration:
```
Hosted
Debug enabled
Vault disabled
CVV Verification enabled
3D Secure Verification disabled
Auto Capture disabled
```


While proceeding checkout as a guest customer after redirecting back from `https://secure1.checkout.com/sandbox/payment/` with successful validated payment receiving next issue:

```
Error Code 70000: Validation error
Validation error
```

Debug information: behind `70000` ➛`70015` Field 'email' is required

```php
//vendor/checkoutcom/magento2/Gateway/Http/Client/AbstractTransaction.php::placeRequest():149
$response           = $client->request();

//Response:
//{"eventId":"613bdde4-9f33-46df-a84d-0f3517c3d02a","errorCode":"70000","message":"Validation error","errorMessageCodes":["70055"],"errors":["Require either a 'customerId' or 'email' value"]}

$exception = new ApiClientException($result['message'], $result['errorCode'], $result['eventId']);
```

Issue based on: Magento\Quote\Model\Quote have customer_email field set to NULL
After payment processing on checkout.com side, PlaceOrder (`CheckoutCom\Magento2\Controller\Payment\PlaceOrder::execute()`) action is requested on return from checkout.com.
Card Token and Email parameters are passed from checkout.com through GET-method and defined in execute:

```php
#vendor/checkoutcom/magento2/Controller/Payment/PlaceOrder.php:49
        $cardToken      = $this->getRequest()->getParam('cko-card-token');
        $email          = $this->getRequest()->getParam('cko-context-id');
```

But $email then never used.

So as now we set email from HTML 5 Local Storage to Customer Session and after Payment we check if Customer is Guest and there is same email in Customer Session that is sent from Checkout.com, if true then we set it to current Quote.