### PR TITLE
Fix correct state assignment

### DIFF
--- a/Controller/Payment/Verify.php
+++ b/Controller/Payment/Verify.php
@@ -234,6 +234,7 @@ class Verify extends AbstractAction {
         try {
 
             // Create order from quote
+            /** @var \Magento\Sales\Model\Order $order */
             $order = $this->quoteManagement->submit($quote);
             
             // Prepare the order in session (required for success page redirection)
@@ -243,8 +244,7 @@ class Verify extends AbstractAction {
                                        ->setLastOrderStatus($order->getStatus());
             
                 // Update order status
-                $order->setState('new');
-                $order->setStatus($this->gatewayConfig->getNewOrderStatus());
+                $this->watchdog->updateOrderStatus($order, $this->gatewayConfig->getNewOrderStatus());
 
                 // Set email sent
                 $order->setEmailSent(1);

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -53,6 +53,7 @@ class Config extends BaseConfig {
     const KEY_THEME_COLOR = 'theme_color';
     const KEY_BUTTON_LABEL = 'button_label';
 
+    const KEY_ORDER_STATUS = 'order_status';
     const KEY_NEW_ORDER_STATUS = 'new_order_status';
     const KEY_ACCEPTED_CURRENCIES = 'accepted_currencies';
     const KEY_PAYMENT_CURRENCY = 'payment_currency';
@@ -117,6 +118,15 @@ class Config extends BaseConfig {
      */
     public function getAutoGenerateInvoice() {
         return (bool) $this->getValue(self::KEY_AUTO_GENERATE_INVOICE);
+    }
+
+    /**
+     * Returns order status.
+     *
+     * @return string
+     */
+    public function getOrderStatus() {
+        return (string) $this->getValue(self::KEY_ORDER_STATUS);
     }
 
     /**

--- a/Model/Adminhtml/Source/PaymentAction.php
+++ b/Model/Adminhtml/Source/PaymentAction.php
@@ -16,6 +16,7 @@ class PaymentAction implements ArrayInterface
 {
 
     const ACTION_AUTHORIZE = 'authorize';
+    const ACTION_CAPTURE = 'capture';
     const ACTION_AUTHORIZE_CAPTURE = 'authorize_capture';
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -41,6 +41,13 @@
                         <config_path>payment/checkout_com/sort_order</config_path>
                     </field>
 
+                    <field id="order_status" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Order status</label>
+                        <source_model>CheckoutCom\Magento2\Model\Adminhtml\Source\OrderStatus</source_model>
+                        <config_path>payment/checkout_com/order_status</config_path>
+                        <comment>Select the status that should be used for new orders with authorized payment confirmation.</comment>
+                    </field>
+
                     <field id="new_order_status" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>New order status</label>
                         <source_model>CheckoutCom\Magento2\Model\Adminhtml\Source\OrderStatus</source_model>


### PR DESCRIPTION
Environment set

```
Server version: Apache/2.4.18 (Ubuntu)
PHP 7.0.15-0ubuntu0.16.04.4
magento/product-enterprise-edition: 2.1.9
```

Module configuration:
```
Hosted enabled
Debug enabled
Vault disabled
CVV Verification enabled
3D Secure Verification enabled
Auto Capture enabled
```

Currently there is 3 placed where State and Status set up hardcoded to 
```php
$order->setState('new');
$order->setStatus('pending');
```
or
```php
$order->setState('new');
$order->setStatus($this->gatewayConfig->getNewOrderStatus());
```

both cased are not correct and can cause additional issues in different cases. 
Meanwhile in `config.xml` already exists prepared but unfortunately not used setting 
```xml
<order_status>processing</order_status>
```

So as a solution all state and status changes were moved to one function that finds corresponding state for given status. For `CallbackService` was added call for Order Status defined in admin setting depending on currently provided command:
```php
$commandName == PaymentAction::ACTION_CAPTURE ? $this->gatewayConfig->getNewOrderStatus() : $this->gatewayConfig->getOrderStatus()
```