### PR TITLE
Update billing address in quote after change

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/hosted.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted.js
@@ -23,6 +23,8 @@ define(
     function ($, Component, VaultEnabler, CheckoutCom, quote, url, additionalValidators) {
         'use strict';
 
+        window.checkoutConfig.reloadOnBillingAddress = true;
+
         return Component.extend({
             defaults: {
                 active: true,


### PR DESCRIPTION
Environment set

```
Server version: Apache/2.4.18 (Ubuntu)
PHP 7.0.15-0ubuntu0.16.04.4
magento/product-enterprise-edition: 2.1.9
```
Module configuration:

```
Hosted enabled
Debug enabled
Vault disabled
CVV Verification enabled
3D Secure Verification enabled
Auto Capture enabled
```

While proceeding checkout on payment page Customer changing Billing Address to custom one, but this information is not saved due to redirection. As a solution billing address is saved while generic magento-checkout UpdateAddresses procedure after Update button is pressed.