### PR TITLE
No direct objectmanager usage

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -12,6 +12,8 @@ namespace CheckoutCom\Magento2\Gateway\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Payment\Gateway\Config\Config as BaseConfig;
+use Magento\Checkout\Model\Session as CheckoutSession;
+
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\ScopeInterface;
 
@@ -91,6 +93,11 @@ class Config extends BaseConfig {
     private $storeManager;
 
     /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
+
+    /**
      * @param ScopeConfigInterface $scopeConfig
      * @param string|null $methodCode
      * @param string $pathPattern
@@ -98,6 +105,7 @@ class Config extends BaseConfig {
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         StoreManagerInterface $storeManager,
+        CheckoutSession $checkoutSession,
 
         $methodCode = null,
         $pathPattern = self::DEFAULT_PATH_PATTERN
@@ -106,6 +114,7 @@ class Config extends BaseConfig {
 
         $this->scopeConfig  = $scopeConfig;
         $this->storeManager = $storeManager;
+        $this->checkoutSession = $checkoutSession;
     }
 
 
@@ -255,8 +264,7 @@ class Config extends BaseConfig {
      * @return bool
      */
     public function isActive() {
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $quote = $objectManager->create('Magento\Checkout\Model\Session')->getQuote();
+        $quote = $this->checkoutSession->getQuote();
         return (bool) in_array($quote->getQuoteCurrencyCode(), $this->getAcceptedCurrencies());
     }
 

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -13,7 +13,6 @@ namespace CheckoutCom\Magento2\Gateway\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Payment\Gateway\Config\Config as BaseConfig;
 use Magento\Checkout\Model\Session as CheckoutSession;
-
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\ScopeInterface;
 


### PR DESCRIPTION
Updated `CheckoutCom\Magento2\Gateway\Config\Config` not to use directly objectManager.

Recommending also to try out https://github.com/magento/marketplace-eqp which has M2 ruleset for PHP_CodeSniffer. Recommending at least to pass severity 10 which might also reveal some issues before they happen.

Currently it doesn't pass validation due some errors: 

- https://gist.github.com/elvinristi/2c454e851ce23c1b81909d7209c6c416
- i.e. _"Namespace for Zend_Http_Client_Exception class is not specified"_ in `Model/Service/OrderService.php`
