### PR TITLE
Removed encoding in http requests

### DIFF
--- a/Gateway/Http/Client/AbstractTransaction.php
+++ b/Gateway/Http/Client/AbstractTransaction.php
@@ -160,8 +160,6 @@ abstract class AbstractTransaction implements ClientInterface {
         }
 
         $client->setHeaders($transferObject->getHeaders());
-        $client->setUrlEncodeBody($transferObject->shouldEncode());
-           
         $client->setUri($this->fullUri);
         
         try {

--- a/Model/Service/OrderService.php
+++ b/Model/Service/OrderService.php
@@ -341,7 +341,6 @@ class OrderService {
         $client->setMethod('POST');
         $client->setRawData( json_encode( $transfer->getBody()) ) ;
         $client->setHeaders($transfer->getHeaders());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
         
         return $client;
     }

--- a/Model/Service/PaymentPlanService.php
+++ b/Model/Service/PaymentPlanService.php
@@ -167,7 +167,6 @@ class PaymentPlanService {
         $client->setMethod('POST');
         $client->setRawData( json_encode( $transfer->getBody()) ) ;
         $client->setHeaders($transfer->getHeaders());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
         
         return $client;
     }

--- a/Model/Service/PaymentTokenService.php
+++ b/Model/Service/PaymentTokenService.php
@@ -135,7 +135,6 @@ class PaymentTokenService {
         $client->setRawData( json_encode( $transfer->getBody()) ) ;
         $client->setHeaders($transfer->getHeaders());
         $client->setConfig($transfer->getClientConfig());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
 
         return $client;
     }

--- a/Model/Service/StoreCardService.php
+++ b/Model/Service/StoreCardService.php
@@ -365,7 +365,6 @@ class StoreCardService {
         $client->setRawData( json_encode( $transfer->getBody()) ) ;
         $client->setHeaders($transfer->getHeaders());
         $client->setConfig($transfer->getClientConfig());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
         
         return $client;
     }

--- a/Model/Service/SubscriptionService.php
+++ b/Model/Service/SubscriptionService.php
@@ -162,7 +162,6 @@ class SubscriptionService {
         $client->setMethod('POST');
         $client->setRawData( json_encode( $transfer->getBody()) ) ;
         $client->setHeaders($transfer->getHeaders());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
         
         return $client;
     }

--- a/Model/Service/TokenChargeService.php
+++ b/Model/Service/TokenChargeService.php
@@ -166,7 +166,6 @@ class TokenChargeService {
         $client->setMethod('POST');
         $client->setRawData( json_encode( $transfer->getBody()) ) ;
         $client->setHeaders($transfer->getHeaders());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
         
         return $client;
     }

--- a/Model/Service/VerifyPaymentService.php
+++ b/Model/Service/VerifyPaymentService.php
@@ -75,7 +75,6 @@ class VerifyPaymentService {
         $client = new ZendClient($this->gatewayConfig->getApiUrl() . $endpoint);
         $client->setMethod('GET');
         $client->setHeaders($transfer->getHeaders());
-        $client->setUrlEncodeBody($transfer->shouldEncode());
 
         return $client;
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "magento/module-vault": "100.2.*"
     },
     "type": "magento2-module",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
Removed the setUrlEncodeBody in client http requests to avoid
alteration of email addresses containing special characters when querying the hub.