### PR TITLE
ConfigProvider update 

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -7,7 +7,7 @@
  *
  * License GNU/GPL V3 https://www.gnu.org/licenses/gpl-3.0.en.html
  */
- 
+
 namespace CheckoutCom\Magento2\Gateway\Config;
 
 use Magento\Payment\Gateway\Config\Config as BaseConfig;
@@ -96,7 +96,7 @@ class Config extends BaseConfig {
      */
     public function getVaultTitle() {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $scopeConfig = $objectManager->create('Magento\Framework\App\Config\ScopeConfigInterface');     
+        $scopeConfig = $objectManager->create('Magento\Framework\App\Config\ScopeConfigInterface');
         return (string) $scopeConfig->getValue('payment/checkout_com_cc_vault/title');
     }
 
@@ -107,7 +107,7 @@ class Config extends BaseConfig {
      */
     public function isCardAutosave() {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $scopeConfig = $objectManager->create('Magento\Framework\App\Config\ScopeConfigInterface');     
+        $scopeConfig = $objectManager->create('Magento\Framework\App\Config\ScopeConfigInterface');
         return (bool) $scopeConfig->getValue('payment/checkout_com_cc_vault/autosave');
     }
 
@@ -243,8 +243,12 @@ class Config extends BaseConfig {
      * @return bool
      */
     public function isActive() {
+        if (!$this->getValue(self::KEY_ACTIVE)) {
+            return false;
+        }
+
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $quote = $objectManager->create('Magento\Checkout\Model\Session')->getQuote();     
+        $quote = $objectManager->create('Magento\Checkout\Model\Session')->getQuote();
         return (bool) in_array($quote->getQuoteCurrencyCode(), $this->getAcceptedCurrencies());
     }
 
@@ -455,8 +459,8 @@ class Config extends BaseConfig {
     public function getCustomCss() {
         // Prepare the objects
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $scopeConfig = $objectManager->create('Magento\Framework\App\Config\ScopeConfigInterface');    
-        $storeManager = $objectManager->create('Magento\Store\Model\StoreManagerInterface');  
+        $scopeConfig = $objectManager->create('Magento\Framework\App\Config\ScopeConfigInterface');
+        $storeManager = $objectManager->create('Magento\Store\Model\StoreManagerInterface');
 
         // Prepare the paths
         $base_url = $storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA);

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -65,10 +65,12 @@ class ConfigProvider implements ConfigProviderInterface {
      * @return array
      */
     public function getConfig() {
+        $isActive = $this->config->isActive();
+
         return [
             'payment' => [
                 self::CODE => [
-                    'isActive'                  => $this->config->isActive(),
+                    'isActive'                  => $isActive,
                     'debug_mode'                => $this->config->isDebugMode(),
                     'public_key'                => $this->config->getPublicKey(),
                     'hosted_url'                => $this->config->getHostedUrl(),
@@ -90,7 +92,7 @@ class ConfigProvider implements ConfigProviderInterface {
                     'design_settings' => $this->config->getDesignSettings(),
                     'accepted_currencies' => $this->config->getAcceptedCurrencies(),
                     'payment_mode' => $this->config->getPaymentMode(),
-                    'payment_token' => $this->getPaymentToken(),
+                    'payment_token' => $isActive ? $this->getPaymentToken() : '',
                     'quote_value' => $this->getQuoteValue(),
                     'quote_currency' => $this->getQuoteCurrency(),
                     'embedded_theme' => $this->config->getEmbeddedTheme(),
@@ -123,7 +125,7 @@ class ConfigProvider implements ConfigProviderInterface {
         // Return the quote amount
         return $this->checkoutSession->getQuote()->getGrandTotal()*100;
     }
-   
+
     /**
      * Get a quote currency code.
      *


### PR DESCRIPTION
Call `getPaymentToken` only when module is enabled.

Triggered unneeded token calls to checkout.com webservice and resulting 404 notices in session message when module not configured.

Extended also `Config::isActive` to check if module setting is enabled.
