### PR TITLE
Fix module name typo in add-new-card-form.phtml forms

### DIFF
--- a/view/adminhtml/templates/add-new-card-form.phtml
+++ b/view/adminhtml/templates/add-new-card-form.phtml
@@ -15,7 +15,7 @@
 <br>
 <div id="cko-form-holder" style="display: none;">
     <form class="widget-container" id="embeddedForm" method="POST">
-        <?php echo $this->getLayout()->createBlock('CheckoutCom\Magento2\Block\Embedded')->setTemplate('Checkoutcom_Magento2::embedded.phtml')->toHtml(); ?>
+        <?php echo $this->getLayout()->createBlock('CheckoutCom\Magento2\Block\Embedded')->setTemplate('CheckoutCom_Magento2::embedded.phtml')->toHtml(); ?>
 	</form>
     <div class="actions-toolbar">
         <div class="primary">

--- a/view/frontend/templates/add-new-card-form.phtml
+++ b/view/frontend/templates/add-new-card-form.phtml
@@ -15,7 +15,7 @@
 <br>
 <div id="cko-form-holder" style="display: none;">
     <form class="widget-container" id="embeddedForm" method="POST">
-        <?php echo $this->getLayout()->createBlock('CheckoutCom\Magento2\Block\Embedded')->setTemplate('Checkoutcom_Magento2::embedded.phtml')->toHtml(); ?>
+        <?php echo $this->getLayout()->createBlock('CheckoutCom\Magento2\Block\Embedded')->setTemplate('CheckoutCom_Magento2::embedded.phtml')->toHtml(); ?>
 	</form>
 	<br>
     <div class="actions-toolbar">


### PR DESCRIPTION
Fixes typo when referencing `embedded.phtml` template in `add-new-card-form.phtml` forms.

If using `Checkoutcom_Magento2` (lowercase `c`) you might get an error as PHP is not able to resolve the module name correctly. Using the correct module name (`CheckoutCom_Magento2` - capital `C`) solves the issue.

Here is the exception reported by magento:

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'Checkoutcom_Magento2::embedded.phtml' in module: 'CheckoutCom_Magento2' block's name: 'embedded_0'
```