### PR TITLE
Plugin improvement

### DIFF
--- a/Controller/Payment/PaymentToken.php
+++ b/Controller/Payment/PaymentToken.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Checkout.com Magento 2 Payment module (https://www.checkout.com)
+ *
+ * Copyright (c) 2017 Checkout.com (https://www.checkout.com)
+ * Author: David Fiaty | integration@checkout.com
+ *
+ * License GNU/GPL V3 https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
+
+namespace CheckoutCom\Magento2\Controller\Payment;
+
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\App\Action\Context;
+use CheckoutCom\Magento2\Model\Service\PaymentTokenService;
+use CheckoutCom\Magento2\Gateway\Config\Config as GatewayConfig;
+
+class PaymentToken extends AbstractAction {
+
+    /**
+     * @var PaymentTokenService
+     */
+    protected $paymentTokenService;
+
+    /**
+     * @var JsonFactory
+     */
+    protected $resultJsonFactory;
+
+    /**
+     * PaymentToken constructor.
+     * @param PaymentTokenService $paymentTokenService
+     * @param JsonFactory $resultJsonFactory
+     */
+    public function __construct(
+        Context $context, 
+        PaymentTokenService $paymentTokenService,
+        JsonFactory $resultJsonFactory,
+        GatewayConfig $gatewayConfig
+    ) 
+    {
+        parent::__construct($context, $gatewayConfig);
+        $this->paymentTokenService  = $paymentTokenService;
+        $this->resultJsonFactory    = $resultJsonFactory;
+    }
+
+    /**
+     * Handles the controller method.
+     */
+    public function execute() {
+        return $this->resultJsonFactory->create()->setData([
+            'payment_token' => $this->paymentTokenService->getToken()
+        ]);
+    }
+}

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -15,7 +15,6 @@ use Magento\Checkout\Model\Session;
 use Magento\Store\Model\StoreManagerInterface;
 use CheckoutCom\Magento2\Gateway\Config\Config;
 use CheckoutCom\Magento2\Model\Adapter\ChargeAmountAdapter;
-use CheckoutCom\Magento2\Model\Service\PaymentTokenService;
 
 class ConfigProvider implements ConfigProviderInterface {
 
@@ -36,11 +35,6 @@ class ConfigProvider implements ConfigProviderInterface {
     protected $checkoutSession;
 
     /**
-     * @var PaymentTokenService
-     */
-    protected $paymentTokenService;
-
-    /**
      * @var StoreManagerInterface
      */
     protected $storeManager;
@@ -48,13 +42,11 @@ class ConfigProvider implements ConfigProviderInterface {
     /**
      * ConfigProvider constructor.
      * @param Config $config
-     * @param PaymentTokenService $paymentTokenService
      * @param Session $checkoutSession
      * @param StoreManagerInterface $storeManager
      */
-    public function __construct(Config $config, PaymentTokenService $paymentTokenService, Session $checkoutSession, StoreManagerInterface $storeManager) {
+    public function __construct(Config $config, Session $checkoutSession, StoreManagerInterface $storeManager) {
         $this->config = $config;
-        $this->paymentTokenService  = $paymentTokenService;
         $this->checkoutSession = $checkoutSession;
         $this->storeManager = $storeManager;
     }
@@ -92,7 +84,6 @@ class ConfigProvider implements ConfigProviderInterface {
                     'design_settings' => $this->config->getDesignSettings(),
                     'accepted_currencies' => $this->config->getAcceptedCurrencies(),
                     'payment_mode' => $this->config->getPaymentMode(),
-                    'payment_token' => $isActive ? $this->getPaymentToken() : '',
                     'quote_value' => $this->getQuoteValue(),
                     'quote_currency' => $this->getQuoteCurrency(),
                     'embedded_theme' => $this->config->getEmbeddedTheme(),
@@ -105,15 +96,6 @@ class ConfigProvider implements ConfigProviderInterface {
                 ],
             ],
         ];
-    }
-
-    /**
-     * Get a payment token.
-     *
-     * @return string
-     */
-    public function getPaymentToken() {
-        return $this->paymentTokenService->getToken();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "magento/module-vault": "*"
     },
     "type": "magento2-module",
-    "version": "1.0.32",
+    "version": "1.0.33",
     "autoload": {
         "files": [
             "registration.php"

--- a/view/frontend/web/js/view/payment/method-renderer/hosted.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted.js
@@ -65,8 +65,7 @@ define(
                 });
 
                 // Process the payment token response
-                ajaxRequest.done(function (response, textStatus, jqXHR){
-                    console.log(response);
+                ajaxRequest.done(function (response, textStatus, jqXHR) {
                     $('#paymentToken').val(response.payment_token);
                 });
             },

--- a/view/frontend/web/js/view/payment/method-renderer/hosted.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted.js
@@ -58,7 +58,17 @@ define(
              * @returns {string}
              */
             getPaymentToken: function() {                
-                return CheckoutCom.getPaymentConfig()['payment_token'];
+                // Send the request
+                var ajaxRequest = $.ajax({
+                    url: url.build('checkout_com/payment/paymentToken'),
+                    type: "post"
+                });
+
+                // Process the payment token response
+                ajaxRequest.done(function (response, textStatus, jqXHR){
+                    console.log(response);
+                    $('#paymentToken').val(response.payment_token);
+                });
             },
 
             /**

--- a/view/frontend/web/template/payment/hosted.html
+++ b/view/frontend/web/template/payment/hosted.html
@@ -48,7 +48,7 @@
             <input name="logoUrl" data-bind="attr: {value: getDesignSettings()['hosted']['logo_url']}">
             <!-- /ko -->
             <!-- ko if: (getPaymentMode() === "localpayments" || getPaymentMode() === "mixed") -->
-            <input name="paymentToken" data-bind="attr: {value: getPaymentToken()}">
+            <input id ="paymentToken" name="paymentToken" data-bind="attr: {value: getPaymentToken()}">
             <!-- /ko -->
         </form>
 


### PR DESCRIPTION
Make the payment token call asynchronous on the last checkout step to improve compatibility with third party One Step Checkout plugins.