### PR TITLE
Fix multiple emal send for Frames integration.

### DIFF
--- a/Model/Service/CallbackService.php
+++ b/Model/Service/CallbackService.php
@@ -179,8 +179,9 @@ class CallbackService {
                 // Update order status
                 $order->setStatus($this->gatewayConfig->getOrderStatusAuthorized());
 
-                // Send the email only if it hasn't been sent
-                if (!$order->getEmailSent()) {
+                // Send the email only for Hosted integration only if it hasn't been sent
+                // Frames is using the core placeOrder email sender and doesn't need manual action.
+                if ($this->gatewayConfig->isHostedIntegration() && !$order->getEmailSent()) {
                     $this->orderSender->send($order);
                     $order->setEmailSent(1);
                 }


### PR DESCRIPTION
Because this class calls from webhook callback and there is no locking mechanism to check real order values between parallel threads, returning back checking by intergration type will restrict this issue to hosted integration only.