### PR TITLE
Fix "70000 - Validation error" on void order

### DIFF
--- a/Gateway/Http/Client/AbstractTransaction.php
+++ b/Gateway/Http/Client/AbstractTransaction.php
@@ -150,10 +150,10 @@ abstract class AbstractTransaction implements ClientInterface {
 
         switch($this->getMethod()) {
             case \Zend_Http_Client::GET:
-                $client->setRawData( json_encode($this->body) ) ;
+                $client->setRawData( json_encode($this->body, JSON_FORCE_OBJECT) ) ;
                 break;
             case \Zend_Http_Client::POST:
-                $client->setRawData( json_encode($this->body) ) ;
+                $client->setRawData( json_encode($this->body, JSON_FORCE_OBJECT) ) ;
                 break;
             default:
                 throw new \LogicException( sprintf('Unsupported HTTP method %s', $transferObject->getMethod()) );


### PR DESCRIPTION
"An error was experienced while parsing the payload. Please ensure that the structure is correct."

This errors happens when void order.

Steps to reproduce:
1) Place Order (without autocapture enabled in module config).
2) Invoice order with "Capture Offline".
3) Click "Void" button.

![image](https://user-images.githubusercontent.com/603401/54325354-c6ca1980-4612-11e9-92a8-cb7430be0c06.png)

It's happens because body is empty array for void request, that serialized to "[]" by json_encode() without `JSON_FORCE_OBJECT` in second paramater.