### PR TITLE
Remove type parameter from URL getters

### DIFF
--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -154,7 +154,7 @@ class ConfigProvider implements ConfigProviderInterface {
      * @return string
      */
     public function getSuccessUrl() {
-        $url = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB) . 'checkout_com/payment/verify';
+        $url = $this->storeManager->getStore()->getBaseUrl() . 'checkout_com/payment/verify';
         return $url;
     }
 
@@ -164,7 +164,7 @@ class ConfigProvider implements ConfigProviderInterface {
      * @return string
      */
     public function getFailUrl() {
-        $url = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB) . 'checkout_com/payment/fail';
+        $url = $this->storeManager->getStore()->getBaseUrl() . 'checkout_com/payment/fail';
         return $url;
     }
 }


### PR DESCRIPTION
On a default Magento instance where URL rewriting is disabled, index.php is in the URL - but this isn't included in the getBaseUrl function when the URL_TYPE_WEB parameter is passed in. This then causes a 404 error on redirections after payment, as Checkout.com's redirect URLs doesn't include index.php.

To fix this (**not tested**), we can remove the URL type being passed through - which defaults to the option of including the index.php path, if rewriting is disabled, and excludes it if rewriting is enabled.