### PR TITLE
Improved the sdk exception handler

### DIFF
--- a/Model/Methods/ApplePayMethod.php
+++ b/Model/Methods/ApplePayMethod.php
@@ -110,6 +110,11 @@ class ApplePayMethod extends \Magento\Payment\Model\Method\AbstractMethod
     public $quoteHandler;
 
     /**
+     * @var Logger
+     */
+    public $ckoLogger;
+
+    /**
      * @var ManagerInterface
      */
     public $messageManager;
@@ -143,6 +148,7 @@ class ApplePayMethod extends \Magento\Payment\Model\Method\AbstractMethod
         \CheckoutCom\Magento2\Helper\Utilities $utilities,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \CheckoutCom\Magento2\Model\Service\QuoteHandlerService $quoteHandler,
+        \CheckoutCom\Magento2\Helper\Logger $ckoLogger,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
@@ -179,6 +185,7 @@ class ApplePayMethod extends \Magento\Payment\Model\Method\AbstractMethod
         $this->utilities          = $utilities;
         $this->storeManager       = $storeManager;
         $this->quoteHandler       = $quoteHandler;
+        $this->ckoLogger          = $ckoLogger;
         $this->messageManager     = $messageManager;
     }
 
@@ -264,11 +271,16 @@ class ApplePayMethod extends \Magento\Payment\Model\Method\AbstractMethod
         $request->metadata['quoteData'] = json_encode($this->quoteHandler->getQuoteRequestData($quote));
 
         // Send the charge request
-        $response = $api->checkoutApi
-            ->payments()
-            ->request($request);
-        
-        return $response;
+        try {
+            $response = $api->checkoutApi
+                ->payments()->request($request);
+        }
+        catch (CheckoutHttpException $e) {
+            $this->ckoLogger->write($e->getBody());
+        }
+        finally {
+            return $response;
+        }
     }
 
     /**

--- a/Model/Methods/CardPaymentMethod.php
+++ b/Model/Methods/CardPaymentMethod.php
@@ -94,6 +94,11 @@ class CardPaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
     public $cardHandler;
 
     /**
+     * @var Logger
+     */
+    public $ckoLogger;
+
+    /**
      * @var ManagerInterface
      */
     public $messageManager;
@@ -158,6 +163,7 @@ class CardPaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \CheckoutCom\Magento2\Model\Service\QuoteHandlerService $quoteHandler,
         \CheckoutCom\Magento2\Model\Service\CardHandlerService $cardHandler,
+        \CheckoutCom\Magento2\Helper\Logger $ckoLogger,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
@@ -195,6 +201,7 @@ class CardPaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         $this->storeManager       = $storeManager;
         $this->quoteHandler       = $quoteHandler;
         $this->cardHandler        = $cardHandler;
+        $this->ckoLogger          = $ckoLogger;
         $this->messageManager     = $messageManager;
     }
 
@@ -288,11 +295,16 @@ class CardPaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         );
         
         // Send the charge request
-        $response = $api->checkoutApi
-            ->payments()
-            ->request($request);
-
-        return $response;
+        try {
+            $response = $api->checkoutApi
+                ->payments()->request($request);
+        }
+        catch (CheckoutHttpException $e) {
+            $this->ckoLogger->write($e->getBody());
+        }
+        finally {
+            return $response;
+        }
     }
 
     /**

--- a/Model/Methods/VaultMethod.php
+++ b/Model/Methods/VaultMethod.php
@@ -119,6 +119,11 @@ class VaultMethod extends \Magento\Payment\Model\Method\AbstractMethod
     public $quoteHandler;
 
     /**
+     * @var Logger
+     */
+    public $ckoLogger;
+
+    /**
      * @var ManagerInterface
      */
     public $messageManager;
@@ -164,6 +169,7 @@ class VaultMethod extends \Magento\Payment\Model\Method\AbstractMethod
         \CheckoutCom\Magento2\Model\Service\VaultHandlerService $vaultHandler,
         \CheckoutCom\Magento2\Model\Service\CardHandlerService $cardHandler,
         \CheckoutCom\Magento2\Model\Service\QuoteHandlerService $quoteHandler,
+        \CheckoutCom\Magento2\Helper\Logger $ckoLogger,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \CheckoutCom\Magento2\Block\Adminhtml\Payment\Moto $motoBlock,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
@@ -203,6 +209,7 @@ class VaultMethod extends \Magento\Payment\Model\Method\AbstractMethod
         $this->vaultHandler       = $vaultHandler;
         $this->cardHandler        = $cardHandler;
         $this->quoteHandler       = $quoteHandler;
+        $this->ckoLogger          = $ckoLogger;
         $this->messageManager     = $messageManager;
         $this->motoBlock          = $motoBlock;
     }
@@ -307,11 +314,16 @@ class VaultMethod extends \Magento\Payment\Model\Method\AbstractMethod
         );
         
         // Send the charge request
-        $response = $api->checkoutApi
-            ->payments()
-            ->request($request);
-
-        return $response;
+        try {
+            $response = $api->checkoutApi
+                ->payments()->request($request);
+        }
+        catch (CheckoutHttpException $e) {
+            $this->ckoLogger->write($e->getBody());
+        }
+        finally {
+            return $response;
+        }
     }
 
     /**


### PR DESCRIPTION
Enabled the use of the Checkout.com PHP SDK HTTP exception handler in order to get more explicit error messages when the gateway declines a payment request.