### PR TITLE
Ecpint 434 moto fix

### DIFF
--- a/Helper/Utilities.php
+++ b/Helper/Utilities.php
@@ -86,8 +86,11 @@ class Utilities
             ->getMethodInstance()
             ->getInfoInstance()
             ->getData();
-
-        return $paymentData['additional_information']['transaction_info'];
+        if (isset($paymentData['additional_information']['transaction_info'])) {
+            return $paymentData['additional_information']['transaction_info'];
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/Observer/Backend/MotoPaymentRequest.php
+++ b/Observer/Backend/MotoPaymentRequest.php
@@ -133,6 +133,9 @@ class MotoPaymentRequest implements \Magento\Framework\Event\ObserverInterface
 
         // Process the payment
         if ($this->needsMotoProcessing()) {
+            // Prepare the response container
+            $response = null;
+
             // Initialize the API handler
             $api = $this->apiHandler->init($storeCode);
 


### PR DESCRIPTION
Fixed error for faulty moto payments where variable isn't set. Initialised transaction response to null.