### PR TITLE
Fix error with amex icons not showing if it was saved with 3ds on

### DIFF
--- a/Model/Service/CardHandlerService.php
+++ b/Model/Service/CardHandlerService.php
@@ -76,6 +76,10 @@ class CardHandlerService
      */
     public function getCardCode($scheme)
     {
+        if($scheme == 'Amex') {
+            $scheme = 'American Express';
+        }
+
         return array_search(
             $scheme,
             self::$cardMapper


### PR DESCRIPTION
When 3ds is on, the Gateway returns the card scheme as ‘Amex’, where the cardMapper expects ‘American Express'. With 3ds off, the gateway returns 'American Express’ as expected.
Added condition to check if scheme is 'Amex', then set it to 'American Express' instead.