### PR TITLE
Removed current order status check when changing void order comment

### DIFF
--- a/Observer/Backend/OrderAfterVoid.php
+++ b/Observer/Backend/OrderAfterVoid.php
@@ -71,28 +71,20 @@ class OrderAfterVoid implements \Magento\Framework\Event\ObserverInterface
 
             // Check if payment method is checkout.com
             if (in_array($methodId, $this->config->getMethodsList())) {
-                if ($this->statusNeedsCorrection($order)) {
-                    // Update the order status
-                    $order->setStatus($this->config->getValue('order_status_voided'));
+                // Update the order status
+                $order->setStatus($this->config->getValue('order_status_voided'));
 
-                    // Get the latest order status comment
-                    $orderComments = $order->getStatusHistories();
-                    $orderComment = array_pop($orderComments);
+                // Get the latest order status comment
+                $orderComments = $order->getStatusHistories();
+                $orderComment = array_pop($orderComments);
 
-                    // Update the order history comment status
-                    $orderComment->setData('status', $this->config->getValue('order_status_voided'))->save();
-                }
+                // Update the order history comment status
+                $orderComment->setData('status', $this->config->getValue('order_status_voided'))->save();
+                
             }
 
             return $this;
         }
     }
 
-    public function statusNeedsCorrection($order)
-    {
-        $currentStatus = $order->getStatus();
-        $desiredStatus = $this->config->getValue('order_status_voided');
-
-        return $currentStatus !== $desiredStatus;
-    }
 }


### PR DESCRIPTION
Regression on the RC - sometimes the void order comment had an incorrect order status. The statusNeedsCorrection check was stopping this from being updated.