### PR TITLE
ECPINT-1728-3ds-fail-issue

### DIFF
--- a/Controller/Payment/Fail.php
+++ b/Controller/Payment/Fail.php
@@ -63,6 +63,11 @@ class Fail extends \Magento\Framework\App\Action\Action
     public $paymentErrorHandlerService;
 
     /**
+     * @var Session
+     */
+    protected $session;
+
+    /**
      * PlaceOrder constructor
      */
     public function __construct(
@@ -74,7 +79,8 @@ class Fail extends \Magento\Framework\App\Action\Action
         \CheckoutCom\Magento2\Model\Service\OrderHandlerService $orderHandler,
         \CheckoutCom\Magento2\Model\Service\OrderStatusHandlerService $orderStatusHandler,
         \CheckoutCom\Magento2\Helper\Logger $logger,
-        \CheckoutCom\Magento2\Model\Service\PaymentErrorHandlerService $paymentErrorHandlerService
+        \CheckoutCom\Magento2\Model\Service\PaymentErrorHandlerService $paymentErrorHandlerService,
+        \Magento\Checkout\Model\Session $session
     ) {
         parent::__construct($context);
 
@@ -86,6 +92,7 @@ class Fail extends \Magento\Framework\App\Action\Action
         $this->orderStatusHandler = $orderStatusHandler;
         $this->logger = $logger;
         $this->paymentErrorHandlerService = $paymentErrorHandlerService;
+        $this->session = $session;
     }
 
     /**
@@ -119,7 +126,7 @@ class Fail extends \Magento\Framework\App\Action\Action
                 $this->orderStatusHandler->handleFailedPayment($order);
 
                 // Restore the quote
-                $this->quoteHandler->restoreQuote($response->reference);
+                $this->session->restoreQuote();
 
                 $errorMessage = null;
                 if (isset($response->actions[0]['response_code'])) {

--- a/Controller/Payment/PlaceOrder.php
+++ b/Controller/Payment/PlaceOrder.php
@@ -77,6 +77,11 @@ class PlaceOrder extends \Magento\Framework\App\Action\Action
     public $logger;
 
     /**
+     * @var Session
+     */
+    protected $session;
+
+    /**
      * @var array
      */
     public $data;
@@ -106,7 +111,8 @@ class PlaceOrder extends \Magento\Framework\App\Action\Action
         \CheckoutCom\Magento2\Model\Service\ApiHandlerService $apiHandler,
         \CheckoutCom\Magento2\Model\Service\PaymentErrorHandlerService $paymentErrorHandler,
         \CheckoutCom\Magento2\Helper\Utilities $utilities,
-        \CheckoutCom\Magento2\Helper\Logger $logger
+        \CheckoutCom\Magento2\Helper\Logger $logger,
+        \Magento\Checkout\Model\Session $session
     ) {
         parent::__construct($context);
 
@@ -121,6 +127,7 @@ class PlaceOrder extends \Magento\Framework\App\Action\Action
         $this->paymentErrorHandler = $paymentErrorHandler;
         $this->utilities = $utilities;
         $this->logger = $logger;
+        $this->session = $session;
     }
 
     /**
@@ -208,7 +215,7 @@ class PlaceOrder extends \Magento\Framework\App\Action\Action
                             }
 
                             // Restore the quote
-                            $this->quoteHandler->restoreQuote($order->getIncrementId());
+                            $this->session->restoreQuote();
 
                             // Handle order on failed payment
                             $this->orderStatusHandler->handleFailedPayment($order);

--- a/Controller/Payment/Verify.php
+++ b/Controller/Payment/Verify.php
@@ -65,6 +65,11 @@ class Verify extends \Magento\Framework\App\Action\Action
     public $logger;
 
     /**
+     * @var Session
+     */
+    protected $session;
+
+    /**
      * Verify constructor
      */
     public function __construct(
@@ -76,7 +81,8 @@ class Verify extends \Magento\Framework\App\Action\Action
         \CheckoutCom\Magento2\Model\Service\QuoteHandlerService $quoteHandler,
         \CheckoutCom\Magento2\Model\Service\VaultHandlerService $vaultHandler,
         \CheckoutCom\Magento2\Helper\Utilities $utilities,
-        \CheckoutCom\Magento2\Helper\Logger $logger
+        \CheckoutCom\Magento2\Helper\Logger $logger,
+        \Magento\Checkout\Model\Session $session
     ) {
         parent::__construct($context);
 
@@ -88,6 +94,7 @@ class Verify extends \Magento\Framework\App\Action\Action
         $this->vaultHandler = $vaultHandler;
         $this->utilities = $utilities;
         $this->logger = $logger;
+        $this->session = $session;
     }
 
     /**
@@ -135,7 +142,7 @@ class Verify extends \Magento\Framework\App\Action\Action
                             return $this->_redirect('checkout/onepage/success', ['_secure' => true]);
                         } else {
                             // Restore the quote
-                            $this->quoteHandler->restoreQuote($response->reference);
+                            $this->session->restoreQuote();
 
                             // Add and error message
                             $this->messageManager->addErrorMessage(

--- a/Model/Service/QuoteHandlerService.php
+++ b/Model/Service/QuoteHandlerService.php
@@ -124,20 +124,6 @@ class QuoteHandlerService
     }
 
     /**
-     * Restore a quote
-     */
-    public function restoreQuote($reference)
-    {
-        // Get the quote
-        $quote = $this->getQuote([
-            'reserved_order_id' => $reference
-        ]);
-
-        // Restore the quote
-        $quote->setIsActive(true)->save();
-    }
-
-    /**
      * Create a new quote
      */
     public function createQuote($currency = null, $customer = null)


### PR DESCRIPTION
The old mechanism to restore the quote was only setting it to active in the db. Now that the mini basket is being cleared correctly it needs to be restored in the session and db