### PR TITLE
Ecpint 1540 order cancel void

### DIFF
--- a/Model/Methods/CardPaymentMethod.php
+++ b/Model/Methods/CardPaymentMethod.php
@@ -352,11 +352,6 @@ class CardPaymentMethod extends AbstractMethod
 
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
-
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -398,10 +393,6 @@ class CardPaymentMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -445,10 +436,6 @@ class CardPaymentMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;

--- a/Model/Methods/GooglePayMethod.php
+++ b/Model/Methods/GooglePayMethod.php
@@ -290,10 +290,6 @@ class GooglePayMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -335,10 +331,6 @@ class GooglePayMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -381,10 +373,6 @@ class GooglePayMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;

--- a/Model/Methods/MotoMethod.php
+++ b/Model/Methods/MotoMethod.php
@@ -172,10 +172,6 @@ class MotoMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -218,10 +214,6 @@ class MotoMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -264,10 +256,6 @@ class MotoMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;

--- a/Model/Methods/VaultMethod.php
+++ b/Model/Methods/VaultMethod.php
@@ -330,10 +330,6 @@ class VaultMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;
@@ -374,11 +370,7 @@ class VaultMethod extends AbstractMethod
 
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
-    
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
+
         }
 
         return $this;
@@ -421,10 +413,6 @@ class VaultMethod extends AbstractMethod
             // Set the transaction id from response
             $payment->setTransactionId($response->action_id);
 
-            // Display a message
-            $this->messageManager->addSuccessMessage(__(
-                'Please reload the page to view the updated order information.'
-            ));
         }
 
         return $this;

--- a/Model/Service/OrderStatusHandlerService.php
+++ b/Model/Service/OrderStatusHandlerService.php
@@ -192,11 +192,6 @@ class OrderStatusHandlerService
     public function void()
     {
         $this->status = $this->config->getValue('order_status_voided');
-        $this->state = $this->orderModel::STATE_CANCELED;
-
-        if ($this->order->getState() !== 'canceled') {
-            $this->orderModel->loadByIncrementId($this->order->getIncrementId())->cancel();
-        }
     }
 
     /**

--- a/Model/Service/OrderStatusHandlerService.php
+++ b/Model/Service/OrderStatusHandlerService.php
@@ -205,11 +205,6 @@ class OrderStatusHandlerService
     public function void()
     {
         $this->status = $this->config->getValue('order_status_voided');
-        $this->state = $this->orderModel::STATE_CANCELED;
-
-        if ($this->order->getState() !== 'canceled') {
-            $this->orderModel->loadByIncrementId($this->order->getIncrementId())->cancel();
-        }
     }
 
     /**

--- a/Observer/Backend/OrderAfterVoid.php
+++ b/Observer/Backend/OrderAfterVoid.php
@@ -39,6 +39,11 @@ class OrderAfterVoid implements \Magento\Framework\Event\ObserverInterface
     public $config;
 
     /**
+     * @var OrderManagementInterface
+     */
+    public $orderManagement;
+
+    /**
      * @var Array
      */
     public $params;
@@ -49,11 +54,13 @@ class OrderAfterVoid implements \Magento\Framework\Event\ObserverInterface
     public function __construct(
         \Magento\Backend\Model\Auth\Session $backendAuthSession,
         \Magento\Framework\App\RequestInterface $request,
-        \CheckoutCom\Magento2\Gateway\Config\Config $config
+        \CheckoutCom\Magento2\Gateway\Config\Config $config,
+        \Magento\Sales\Api\OrderManagementInterface $orderManagement
     ) {
         $this->backendAuthSession = $backendAuthSession;
         $this->request = $request;
         $this->config = $config;
+        $this->orderManagement = $orderManagement;
     }
 
     /**
@@ -81,6 +88,9 @@ class OrderAfterVoid implements \Magento\Framework\Event\ObserverInterface
                 // Update the order history comment status
                 $orderComment->setData('status', $this->config->getValue('order_status_voided'))->save();
                 
+                if ($this->config->getValue('order_status_voided') == 'canceled') {
+                    $this->orderManagement->cancel($order->getId());
+                }
             }
 
             return $this;

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -35,7 +35,6 @@
                 <order_status_authorized>pending_payment</order_status_authorized>
                 <order_status_captured>processing</order_status_captured>
                 <order_status_voided>canceled</order_status_voided>
-                <order_status_canceled>canceled</order_status_canceled>
                 <order_status_refunded>closed</order_status_refunded>
                 <order_status_flagged>fraud</order_status_flagged>
                 <order_action_failed_payment>cancel</order_action_failed_payment>

--- a/i18n/en_GB.csv
+++ b/i18n/en_GB.csv
@@ -82,7 +82,6 @@ Webhook,Webhook
 "The void request could not be processed.","The void request could not be processed."
 "The refund action is not available.","The refund action is not available."
 "The refund request could not be processed.","The refund request could not be processed."
-"Please reload the page to view the updated order information.","Please reload the page to view the updated order information."
 "The CVV value is required.","The CVV value is required."
 "There is no quote available to place an order.","There is no quote available to place an order."
 "A payment method ID is required to place an order.","A payment method ID is required to place an order."

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -82,7 +82,6 @@ Webhook,Webhook
 "The void request could not be processed.","The void request could not be processed."
 "The refund action is not available.","The refund action is not available."
 "The refund request could not be processed.","The refund request could not be processed."
-"Please reload the page to view the updated order information.","Please reload the page to view the updated order information."
 "The CVV value is required.","The CVV value is required."
 "There is no quote available to place an order.","There is no quote available to place an order."
 "A payment method ID is required to place an order.","A payment method ID is required to place an order."


### PR DESCRIPTION
* On void we now only cancel the order if the void order status = cancelled
* Fix for item status not being updated
* Removed 'reload the page' message as it is no longer need
* Removed order_status_canceled for config.xml as the merchant cannot change this