### PR TITLE
Added order comment for failed 3ds payments.

### DIFF
--- a/Controller/Payment/Fail.php
+++ b/Controller/Payment/Fail.php
@@ -115,6 +115,12 @@ class Fail extends \Magento\Framework\App\Action\Action
                     'increment_id' => $response->reference
                 ]);
 
+                // Log the payment error
+                $this->paymentErrorHandlerService->logPaymentError(
+                    $response,
+                    $order
+                );
+
                 // Handle the failed order
                 $this->orderStatusHandler->handleFailedPayment($order);
 

--- a/Model/Service/OrderHandlerService.php
+++ b/Model/Service/OrderHandlerService.php
@@ -238,4 +238,21 @@ class OrderHandlerService
 
         return $order;
     }
+
+    /**
+     * Get status history by id
+     * 
+     * @param $entity
+     * @param $order
+     * @return false|mixed
+     */
+    public function getStatusHistoryByEntity($entity, $order)
+    {
+        foreach ($order->getStatusHistoryCollection() as $status) {
+            if ($status->getEntityName() == $entity) {
+                return $status;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
We now add an order comment for failed 3ds challenge. As there is no webhook from the gateway this is done on the payment fail controller. For failed payments that do have a webhook, this comment is then updated to add the additional information that the webhook provides