### PR TITLE
Ecpint 1803 automatic webhook config

### DIFF
--- a/Block/Adminhtml/System/Config/Field/AbstractCallbackUrl.php
+++ b/Block/Adminhtml/System/Config/Field/AbstractCallbackUrl.php
@@ -102,6 +102,18 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                 $scope,
                 $storeCode
             );
+            
+            $publicKey = $this->scopeConfig->getValue(
+                'settings/checkoutcom_configuration/public_key',
+                $scope,
+                $storeCode
+            );
+
+            $secretKey = $this->scopeConfig->getValue(
+                'settings/checkoutcom_configuration/secret_key',
+                $scope,
+                $storeCode
+            );
 
             // Retrieve all configured webhooks
             $webhooks = $api->checkoutApi->webhooks()->retrieve();
@@ -125,17 +137,29 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                 $element->setData('value', $callbackUrl);
                 $element->setReadonly('readonly');
 
-                $this->addData(
-                    [
-                        'element_html'      => $element->getElementHtml(),
-                        'button_label'      => 'set webhooks',
-                        'message'           => 'Attention, webhook not properly configured!',
-                        'message_class'     => 'no-webhook',
-                        'webhook_button'    => true,
-                        'scope'             => $scope,
-                        'scope_id'          => $storeCode
-                    ]
-                );
+                if (empty($publicKey) || empty($secretKey)) {
+                    $this->addData(
+                        [
+                            'element_html' => $element->getElementHtml(),
+                            'button_label' => 'set webhooks',
+                            'hidden' => false,
+                            'scope' => $scope,
+                            'scope_id' => $storeCode
+                        ]
+                    );
+                } else {
+                    $this->addData(
+                        [
+                            'element_html' => $element->getElementHtml(),
+                            'button_label' => 'set webhooks',
+                            'message' => 'Attention, webhook not properly configured!',
+                            'message_class' => 'no-webhook',
+                            'hidden' => false,
+                            'scope' => $scope,
+                            'scope_id' => $storeCode
+                        ]
+                    );
+                }
                 return $this->_toHtml();
             } else {
                 // Webhook configured
@@ -147,7 +171,7 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                         'element_html'      => $element->getElementHtml(),
                         'message'           => 'Your webhook is all set!',
                         'message_class'     => 'webhook-set',
-                        'webhook_button'   => false
+                        'hidden'            => true
                     ]
                 );
                 return $this->_toHtml();
@@ -157,12 +181,40 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
             $element->setData('value', $callbackUrl);
             $element->setReadonly('readonly');
 
-            $this->addData(
-                [
-                    'element_html'      => $element->getElementHtml(),
-                    'webhook_button'   => false
-                ]
+            $publicKey = $this->scopeConfig->getValue(
+                'settings/checkoutcom_configuration/public_key',
+                $scope,
+                $storeCode
             );
+
+            $secretKey = $this->scopeConfig->getValue(
+                'settings/checkoutcom_configuration/secret_key',
+                $scope,
+                $storeCode
+            );
+            
+            if (empty($publicKey) && empty($secretKey)) {
+                $this->addData(
+                    [
+                        'element_html'      => $element->getElementHtml(),
+                        'hidden'            => true,
+                        'scope'             => $scope,
+                        'scope_id'          => $storeCode
+                    ]
+                );
+            } else {
+                $this->addData(
+                    [
+                        'element_html'      => $element->getElementHtml(),
+                        'message'           => 'Attention, public or secret key incorrect!',
+                        'message_class'     => 'no-webhook',
+                        'hidden'            => true,
+                        'scope'             => $scope,
+                        'scope_id'          => $storeCode
+                    ]
+                );
+            }
+
             return $this->_toHtml();
         }
     }

--- a/Block/Adminhtml/System/Config/Field/AbstractCallbackUrl.php
+++ b/Block/Adminhtml/System/Config/Field/AbstractCallbackUrl.php
@@ -80,19 +80,19 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
     protected function _getElementHtml(AbstractElement $element)
     {
         // Get the selected scope and id
-        try {
-            if (array_key_exists('website', $this->getRequest()->getParams())) {
-                $scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES;
-                $storeCode = $this->getRequest()->getParam('website', 0);
-            } else {
-                $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORES;
-                $storeCode = $this->getRequest()->getParam('store', 0);
-                if ($storeCode == 0) {
-                    $scope = 'default';
-                    $storeCode = $this->getRequest()->getParam('site', 0);
-                }
+        if (array_key_exists('website', $this->getRequest()->getParams())) {
+            $scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES;
+            $storeCode = $this->getRequest()->getParam('website', 0);
+        } else {
+            $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORES;
+            $storeCode = $this->getRequest()->getParam('store', 0);
+            if ($storeCode == 0) {
+                $scope = 'default';
+                $storeCode = $this->getRequest()->getParam('site', 0);
             }
-
+        }
+        
+        try {
             // Initialize the API handler
             $api = $this->apiHandler->init($storeCode, $scope);
 
@@ -175,19 +175,13 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
             $element->setData('value', $callbackUrl);
             $element->setReadonly('readonly');
 
-            $publicKey = $this->scopeConfig->getValue(
-                'settings/checkoutcom_configuration/public_key',
-                $scope,
-                $storeCode
-            );
-
             $secretKey = $this->scopeConfig->getValue(
                 'settings/checkoutcom_configuration/secret_key',
                 $scope,
                 $storeCode
             );
             
-            if (empty($publicKey) && empty($secretKey)) {
+            if (empty($secretKey)) {
                 $this->addData(
                     [
                         'element_html'      => $element->getElementHtml(),

--- a/Block/Adminhtml/System/Config/Field/AbstractCallbackUrl.php
+++ b/Block/Adminhtml/System/Config/Field/AbstractCallbackUrl.php
@@ -102,12 +102,6 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                 $scope,
                 $storeCode
             );
-            
-            $publicKey = $this->scopeConfig->getValue(
-                'settings/checkoutcom_configuration/public_key',
-                $scope,
-                $storeCode
-            );
 
             $secretKey = $this->scopeConfig->getValue(
                 'settings/checkoutcom_configuration/secret_key',
@@ -137,11 +131,11 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                 $element->setData('value', $callbackUrl);
                 $element->setReadonly('readonly');
 
-                if (empty($publicKey) || empty($secretKey)) {
+                if (empty($secretKey)) {
                     $this->addData(
                         [
                             'element_html' => $element->getElementHtml(),
-                            'button_label' => 'set webhooks',
+                            'button_label' => __('Set Webhooks'),
                             'hidden' => false,
                             'scope' => $scope,
                             'scope_id' => $storeCode
@@ -151,8 +145,8 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                     $this->addData(
                         [
                             'element_html' => $element->getElementHtml(),
-                            'button_label' => 'set webhooks',
-                            'message' => 'Attention, webhook not properly configured!',
+                            'button_label' => __('Set Webhooks'),
+                            'message' => __('Attention, webhook not properly configured!'),
                             'message_class' => 'no-webhook',
                             'hidden' => false,
                             'scope' => $scope,
@@ -169,7 +163,7 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                 $this->addData(
                     [
                         'element_html'      => $element->getElementHtml(),
-                        'message'           => 'Your webhook is all set!',
+                        'message'           => __('Your webhook is all set!'),
                         'message_class'     => 'webhook-set',
                         'hidden'            => true
                     ]
@@ -206,7 +200,7 @@ abstract class AbstractCallbackUrl extends \Magento\Config\Block\System\Config\F
                 $this->addData(
                     [
                         'element_html'      => $element->getElementHtml(),
-                        'message'           => 'Attention, public or secret key incorrect!',
+                        'message'           => __('Attention, secret key incorrect!'),
                         'message_class'     => 'no-webhook',
                         'hidden'            => true,
                         'scope'             => $scope,

--- a/Controller/Adminhtml/System/Config/Webhook.php
+++ b/Controller/Adminhtml/System/Config/Webhook.php
@@ -91,13 +91,10 @@ class Webhook extends Action
             // Get the store code
             $scope = $this->getRequest()->getParam('scope', 0);
             $storeCode = $this->getRequest()->getParam('scope_id', 0);
-            $customValues = [
-                'publicKey' => $this->getRequest()->getParam('public_key', 0),
-                'secretKey' => $this->getRequest()->getParam('secret_key', 0)
-            ];
+            $secretKey = $this->getRequest()->getParam('secret_key', 0);
 
             // Initialize the API handler
-            $api = $this->apiHandler->init($storeCode, $scope, $customValues);
+            $api = $this->apiHandler->init($storeCode, $scope, $secretKey);
 
             $webhookUrl = $this->scopeConfig->getValue(
                 'payment/checkoutcom/module/account_settings/webhook_url',
@@ -128,7 +125,7 @@ class Webhook extends Action
 
                 $this->resourceConfig->saveConfig(
                     'settings/checkoutcom_configuration/secret_key',
-                    $customValues['secretKey'],
+                    $secretKey,
                     $scope,
                     $storeCode
                 );
@@ -145,7 +142,7 @@ class Webhook extends Action
 
                 $this->resourceConfig->saveConfig(
                     'settings/checkoutcom_configuration/secret_key',
-                    $customValues['secretKey'],
+                    $secretKey,
                     $scope,
                     $storeCode
                 );

--- a/Controller/Adminhtml/System/Config/Webhook.php
+++ b/Controller/Adminhtml/System/Config/Webhook.php
@@ -127,13 +127,6 @@ class Webhook extends Action
                 );
 
                 $this->resourceConfig->saveConfig(
-                    'settings/checkoutcom_configuration/public_key',
-                    $customValues['publicKey'],
-                    $scope,
-                    $storeCode
-                );
-
-                $this->resourceConfig->saveConfig(
                     'settings/checkoutcom_configuration/secret_key',
                     $customValues['secretKey'],
                     $scope,
@@ -146,13 +139,6 @@ class Webhook extends Action
                 $this->resourceConfig->saveConfig(
                     'settings/checkoutcom_configuration/private_shared_key',
                     $response->headers->authorization,
-                    $scope,
-                    $storeCode
-                );
-
-                $this->resourceConfig->saveConfig(
-                    'settings/checkoutcom_configuration/public_key',
-                    $customValues['publicKey'],
                     $scope,
                     $storeCode
                 );

--- a/Model/Service/ApiHandlerService.php
+++ b/Model/Service/ApiHandlerService.php
@@ -95,14 +95,23 @@ class ApiHandlerService
     /**
      * Load the API client.
      */
-    public function init($storeCode = null, $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+    public function init($storeCode = null, $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $customValues = null)
     {
-        $this->checkoutApi = new CheckoutApi(
-            $this->config->getValue('secret_key', null, $storeCode, $scope),
-            $this->config->getValue('environment', null, $storeCode, $scope),
-            $this->config->getValue('public_key', null, $storeCode, $scope)
-        );
-
+        
+        if ($customValues) {
+            $this->checkoutApi = new CheckoutApi(
+                $customValues['secretKey'],
+                $this->config->getValue('environment', null, $storeCode, $scope),
+                $customValues['publicKey']
+            );
+        } else {
+            $this->checkoutApi = new CheckoutApi(
+                $this->config->getValue('secret_key', null, $storeCode, $scope),
+                $this->config->getValue('environment', null, $storeCode, $scope),
+                $this->config->getValue('public_key', null, $storeCode, $scope)
+            );    
+        }
+        
         return $this;
     }
 

--- a/Model/Service/ApiHandlerService.php
+++ b/Model/Service/ApiHandlerService.php
@@ -95,14 +95,12 @@ class ApiHandlerService
     /**
      * Load the API client.
      */
-    public function init($storeCode = null, $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $customValues = null)
+    public function init($storeCode = null, $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $secretKey = null)
     {
-        
-        if ($customValues) {
+        if ($secretKey) {
             $this->checkoutApi = new CheckoutApi(
-                $customValues['secretKey'],
-                $this->config->getValue('environment', null, $storeCode, $scope),
-                $customValues['publicKey']
+                $secretKey,
+                $this->config->getValue('environment', null, $storeCode, $scope)
             );
         } else {
             $this->checkoutApi = new CheckoutApi(
@@ -111,7 +109,7 @@ class ApiHandlerService
                 $this->config->getValue('public_key', null, $storeCode, $scope)
             );    
         }
-        
+
         return $this;
     }
 

--- a/i18n/en_GB.csv
+++ b/i18n/en_GB.csv
@@ -133,3 +133,8 @@ Debitor,Debitor
 "Place Order","Place Order"
 "Card number","Card number"
 "Save this card for later use.","Save this card for later use."
+"Set Webhooks","Set Webhooks"
+"Attention, webhook not properly configured!","Attention, webhook not properly configured!"
+"Your webhook is all set!","Your webhook is all set!"
+"Error! Could not set webhooks. Please check your secret key.","Error! Could not set webhooks. Please check your secret key."
+"Attention, secret key incorrect!","Attention, secret key incorrect!"

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -133,3 +133,8 @@ Debitor,Debitor
 "Place Order","Place Order"
 "Card number","Card number"
 "Save this card for later use.","Save this card for later use."
+"Set Webhooks","Set Webhooks"
+"Attention, webhook not properly configured!","Attention, webhook not properly configured!"
+"Your webhook is all set!","Your webhook is all set!"
+"Error! Could not set webhooks. Please check your secret key.","Error! Could not set webhooks. Please check your secret key."
+"Attention, secret key incorrect!","Attention, secret key incorrect!"

--- a/view/adminhtml/templates/system/config/webhook_admin.phtml
+++ b/view/adminhtml/templates/system/config/webhook_admin.phtml
@@ -1,38 +1,81 @@
 <?php echo $block->getElementHtml(); ?>
-<p class="webhook-message <?= $block->getMessageClass(); ?>"><?= $block->getMessage(); ?></p>
-<?php if ($block->getWebhookButton() == true) { ?>
+<p id="webhook-message" class="webhook-message <?= $block->getMessageClass(); ?>"><?= $block->getMessage(); ?></p>
     <script>
         require([
             'jquery',
             'prototype'
         ], function(jQuery){
-            var webhookSpan = jQuery('#webhook_span');
+            let publicKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][public_key][value]')
+            let secretKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][secret_key][value]')
+            const LIVE_SECRET_KEY_REGEX = /^sk_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
+            const LIVE_PUBLIC_KEY_REGEX = /^pk_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
+            const SANDBOX_SECRET_KEY_REGEX = /^sk_test_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
+            const SANDBOX_PUBLIC_KEY_REGEX = /^pk_test_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
+
+            function checkFormFields()
+            {
+                let environment = document.getElementsByName('groups[checkoutcom][groups][module][groups][global_settings][fields][environment][value]')[0].value
+                if (environment === '1') {
+                    if (!publicKey[0].value.match(SANDBOX_PUBLIC_KEY_REGEX) || !secretKey[0].value.match(SANDBOX_SECRET_KEY_REGEX)) {
+                        return false   
+                    }
+                } else {
+                    if (!publicKey[0].value.match(LIVE_PUBLIC_KEY_REGEX) || !secretKey[0].value.match(LIVE_SECRET_KEY_REGEX)) {
+                        return false
+                    }
+                }
+
+                return true;
+            }
+
+            const inputArray = [
+                publicKey,
+                secretKey
+            ]
+
+            inputArray.forEach(item => {
+                item[0].addEventListener('input', event => {
+                    if (checkFormFields()) {
+                        document.getElementById('webhook_auto_set').style.display = 'block'
+                    } else {
+                        document.getElementById('webhook_auto_set').style.display = 'none'
+                    }
+                })
+            })
 
             jQuery('#webhook_button').click(function () {
                 var params = {
                     scope: '<?= $block->getScope(); ?>',
-                    scope_id: <?= $block->getScopeId(); ?>
+                    scope_id: <?= $block->getScopeId(); ?>,
+                    public_key: publicKey[0].value,
+                    secret_key: secretKey[0].value
                 };
                 new Ajax.Request('<?php echo $block->getAjaxUrl() ?>', {
                     parameters:     params,
                     loaderArea:     false,
                     asynchronous:   true,
                     onCreate: function() {
-                        webhookSpan.find('.processing').show();
+                        document.getElementById('webhook_spinner').style.display = 'initial';
                     },
                     onSuccess: function(response) {
                         if (response.responseJSON.success) {
-                            location.reload();
+                            let privateSharedKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][private_shared_key][value]')
+                            privateSharedKey[0].value = response.responseJSON.privateSharedKey
+                            document.getElementById('webhook-message').textContent = 'Your webhook is all set!'
+                            document.getElementById('webhook-message').classList.toggle('webhook-set')
+                            document.getElementById('webhook_auto_set').style.display = 'none';
                         } else {
-                            alert('Error! Could not set webhooks');
+                            document.getElementById('webhook_spinner').style.display = 'none';
+                            alert('Error! Could not set webhooks. Please check your public and secret key.');
                         }
                     }
                 });
             });
         });
     </script>
-    <?php echo $block->getButtonHtml() ?>
-    <span id="webhook_span">
-        <img class="processing" hidden="hidden" alt="Processing Spinner" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
-    </span>
-<?php } ?>
+    <div id="webhook_auto_set" style="display: <?= ($block->getHidden() == true) ? 'none' : 'block' ?> ">
+        <?php echo $block->getButtonHtml() ?>
+        <span id="webhook_span">
+            <img id="webhook_spinner" style="display: none" alt="Processing Spinner" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
+        </span>
+    </div>

--- a/view/adminhtml/templates/system/config/webhook_admin.phtml
+++ b/view/adminhtml/templates/system/config/webhook_admin.phtml
@@ -49,12 +49,12 @@
                         if (response.responseJSON.success) {
                             let privateSharedKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][private_shared_key][value]')
                             privateSharedKey[0].value = response.responseJSON.privateSharedKey
-                            document.getElementById('webhook-message').textContent = 'Your webhook is all set!'
+                            document.getElementById('webhook-message').textContent = __('Your webhook is all set!')
                             document.getElementById('webhook-message').classList.toggle('webhook-set')
                             document.getElementById('webhook_auto_set').style.display = 'none';
                         } else {
                             document.getElementById('webhook_spinner').style.display = 'none';
-                            alert('Error! Could not set webhooks. Please check your public and secret key.');
+                            alert(__('Error! Could not set webhooks. Please check your secret key.'));
                         }
                     }
                 });

--- a/view/adminhtml/templates/system/config/webhook_admin.phtml
+++ b/view/adminhtml/templates/system/config/webhook_admin.phtml
@@ -49,12 +49,12 @@
                         if (response.responseJSON.success) {
                             let privateSharedKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][private_shared_key][value]')
                             privateSharedKey[0].value = response.responseJSON.privateSharedKey
-                            document.getElementById('webhook-message').textContent = __('Your webhook is all set!')
+                            document.getElementById('webhook-message').textContent = "<?= __('Your webhook is all set!'); ?>"
                             document.getElementById('webhook-message').classList.toggle('webhook-set')
                             document.getElementById('webhook_auto_set').style.display = 'none';
                         } else {
                             document.getElementById('webhook_spinner').style.display = 'none';
-                            alert(__('Error! Could not set webhooks. Please check your secret key.'));
+                            alert("<?= __('Error! Could not set webhooks. Please check your secret key.'); ?>");
                         }
                     }
                 });

--- a/view/adminhtml/templates/system/config/webhook_admin.phtml
+++ b/view/adminhtml/templates/system/config/webhook_admin.phtml
@@ -5,49 +5,37 @@
             'jquery',
             'prototype'
         ], function(jQuery){
-            let publicKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][public_key][value]')
             let secretKey = document.getElementsByName('groups[checkoutcom][groups][module][groups][account_settings][fields][secret_key][value]')
             const LIVE_SECRET_KEY_REGEX = /^sk_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
-            const LIVE_PUBLIC_KEY_REGEX = /^pk_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
             const SANDBOX_SECRET_KEY_REGEX = /^sk_test_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
-            const SANDBOX_PUBLIC_KEY_REGEX = /^pk_test_?(\w{8})-(\w{4})-(\w{4})-(\w{4})-(\w{12})$/;
 
             function checkFormFields()
             {
                 let environment = document.getElementsByName('groups[checkoutcom][groups][module][groups][global_settings][fields][environment][value]')[0].value
                 if (environment === '1') {
-                    if (!publicKey[0].value.match(SANDBOX_PUBLIC_KEY_REGEX) || !secretKey[0].value.match(SANDBOX_SECRET_KEY_REGEX)) {
+                    if (!secretKey[0].value.match(SANDBOX_SECRET_KEY_REGEX)) {
                         return false   
                     }
                 } else {
-                    if (!publicKey[0].value.match(LIVE_PUBLIC_KEY_REGEX) || !secretKey[0].value.match(LIVE_SECRET_KEY_REGEX)) {
+                    if (!secretKey[0].value.match(LIVE_SECRET_KEY_REGEX)) {
                         return false
                     }
                 }
-
                 return true;
             }
 
-            const inputArray = [
-                publicKey,
-                secretKey
-            ]
-
-            inputArray.forEach(item => {
-                item[0].addEventListener('input', event => {
-                    if (checkFormFields()) {
-                        document.getElementById('webhook_auto_set').style.display = 'block'
-                    } else {
-                        document.getElementById('webhook_auto_set').style.display = 'none'
-                    }
-                })
+            secretKey[0].addEventListener('input', event => {
+                if (checkFormFields()) {
+                    document.getElementById('webhook_auto_set').style.display = 'block'
+                } else {
+                    document.getElementById('webhook_auto_set').style.display = 'none'
+                }
             })
 
             jQuery('#webhook_button').click(function () {
                 var params = {
                     scope: '<?= $block->getScope(); ?>',
                     scope_id: <?= $block->getScopeId(); ?>,
-                    public_key: publicKey[0].value,
                     secret_key: secretKey[0].value
                 };
                 new Ajax.Request('<?php echo $block->getAjaxUrl() ?>', {


### PR DESCRIPTION
- You can now use the automatic webhook config for new merchants.
- Uses a regex to validate the secret key 
- Saves the webhook and displays the confirmation message without reloading the page
- You only need the SK to register/update a webhook