### PR TITLE
Ecpint 2092 partial hub refund

### DIFF
--- a/Model/Service/TransactionHandlerService.php
+++ b/Model/Service/TransactionHandlerService.php
@@ -519,12 +519,14 @@ class TransactionHandlerService
             // Refund
             $this->creditMemoService->refund($creditMemo);
 
-            if ($this->order->getStatus() == 'closed') {
-                $status = 'closed';
-            } else {
-                $status = $this->config->getValue('order_status_refunded');
-            }
-            
+            $isPartialRefund = $this->isPartialRefund(
+                $amount,
+                true,
+                $this->order,
+                true
+            );
+
+            $status = $isPartialRefund ? $this->config->getValue('order_status_refunded') : 'closed';
             $orderComment->setData('status', $status)->save();
 
             // Remove the core credit memo comment
@@ -536,16 +538,7 @@ class TransactionHandlerService
             }
 
             // Amend the order status set by magento when refunding the credit memo
-            $isPartialRefund = $this->isPartialRefund(
-                $amount,
-                true,
-                $this->order,
-                true
-            );
-
-            $status = $isPartialRefund ? $this->config->getValue('order_status_refunded') : 'closed';
             $this->order->setStatus($status);
-
             $this->order->setTotalRefunded($currentTotal + $amount);
         }
     }

--- a/Model/Service/TransactionHandlerService.php
+++ b/Model/Service/TransactionHandlerService.php
@@ -520,10 +520,11 @@ class TransactionHandlerService
                 $creditMemo->setBaseShippingAmount(0);
                 $creditMemo->collectTotals();
             } else {
-                $creditMemo = $this->creditMemoFactory->createByOrder($this->order);
-                $creditMemo->setBaseGrandTotal($amount/$this->order->getBaseToOrderRate());
-                $creditMemo->setGrandTotal($amount);
-                $creditMemo->collectTotals();
+                $creditMemoData = [
+                    'adjustment_positive' => $amount,
+                    'adjustment_negative' => $currentTotal + $amount,
+                ];
+                $creditMemo = $this->creditMemoFactory->createByOrder($this->order, $creditMemoData);
             }
 
             // Update the order history comment status

--- a/Model/Service/TransactionHandlerService.php
+++ b/Model/Service/TransactionHandlerService.php
@@ -509,6 +509,7 @@ class TransactionHandlerService
             // Create a credit memo
             $creditMemo = $this->convertor->toCreditmemo($this->order);
             $creditMemo->setAdjustmentPositive($amount);
+            $creditMemo->setBaseShippingAmount(0);
             $creditMemo->collectTotals();
             
             // Update the order history comment status

--- a/Model/Service/TransactionHandlerService.php
+++ b/Model/Service/TransactionHandlerService.php
@@ -523,6 +523,7 @@ class TransactionHandlerService
                 $creditMemo = $this->creditMemoFactory->createByOrder($this->order);
                 $creditMemo->setBaseGrandTotal($amount/$this->order->getBaseToOrderRate());
                 $creditMemo->setGrandTotal($amount);
+                $creditMemo->collectTotals();
             }
 
             // Update the order history comment status

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -387,6 +387,9 @@
                             <field id="merchant_id_certificate"/>
                             <field id="merchant_id"/>
                         </requires>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
                     </field>
                     
                     <field id="enabled_on_cart" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -398,6 +401,9 @@
                             <field id="merchant_id_certificate"/>
                             <field id="merchant_id"/>
                         </requires>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
                     </field>
 
                     <field id="sort_order" type="text" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
Fixed credit memos - Previously partial refunds from the hub would mark all items as refunded and only change the total. Now they will be created using the adjustment amount. Full refunds or partial refunds that set the total refunded amount as the order amount will still refund the items to close the order.

Also adds logic to apple pay config settings