### PR TITLE
ECPINT-2132-api-redirect

### DIFF
--- a/Controller/Payment/Verify.php
+++ b/Controller/Payment/Verify.php
@@ -133,9 +133,10 @@ class Verify extends \Magento\Framework\App\Action\Action
 
                         // Process the response
                         if ($api->isValidResponse($response)) {
-                            if (isset($response->metadata['successUrl'])) {
-                                header('Location: ' . $response->metadata['successUrl']);
-                                exit();
+                            if (isset($response->metadata['successUrl']) &&
+                                !str_contains($response->metadata['successUrl'], 'checkout_com/payment/verify'))
+                            {
+                                return $this->_redirect($response->metadata['successUrl']);
                             } else {
                                 return $this->_redirect('checkout/onepage/success', ['_secure' => true]);
                             }


### PR DESCRIPTION
Fixed an issue where /checkout_com/payment/verify was passed as the custom success_url in API v2. verify.php would redirect to itself.