### PR TITLE
ECPINT-2202-apple-pay-totals

### DIFF
--- a/view/frontend/web/js/view/payment/cart/checkoutcom_applepay_cart.js
+++ b/view/frontend/web/js/view/payment/cart/checkoutcom_applepay_cart.js
@@ -24,6 +24,7 @@ require([
     "Magento_Checkout/js/model/shipping-service",
     "Magento_Customer/js/model/customer",
     "Magento_Customer/js/model/authentication-popup",
+    'Magento_Checkout/js/model/quote',
     "mage/translate",
 ], function (
     $,
@@ -36,6 +37,7 @@ require([
     shippingService,
     Customer,
     AuthPopup,
+    Quote,
     __
 ) {
     $(function () {
@@ -402,6 +404,21 @@ require([
                 "estimate-shipping-methods"
             );
             selectedShippingMethod = shippingMethodsAvailable[0];
+
+            if (Quote.shippingMethod() && Quote.shippingMethod()['method_code']) {
+                let index = 0;
+                shippingMethodsAvailable.forEach(function (method, i) {
+                    if (method.method_code == Quote.shippingMethod()['method_code']) {
+                        selectedShippingMethod = method;
+                        index = i;
+                    }
+                });
+                if (index !== 0) {
+                    shippingMethodsAvailable.splice(index, 1);
+                    shippingMethodsAvailable.unshift(selectedShippingMethod);    
+                }
+            }
+
             return formatShipping(shippingMethodsAvailable);
         }
 


### PR DESCRIPTION
Apple pay on the cart page will now select the shipping method selected in the estimate shipping section

There's no way to pass a default parameter, they just select the first shipping method in the array