### PR TITLE
ECPINT 2377 Klarna not showing

### DIFF
--- a/Model/Methods/AlternativePaymentMethod.php
+++ b/Model/Methods/AlternativePaymentMethod.php
@@ -499,14 +499,12 @@ class AlternativePaymentMethod extends AbstractMethod
         $tax = 0;
         $quote = $this->quoteHandler->getQuote();
         foreach ($quote->getAllVisibleItems() as $item) {
-            $lineTotal = (($item->getPrice() * $item->getQty()) - $item->getDiscountAmount() + $item->getTaxAmount());
-            $price =  ($lineTotal * 100) / $item->getQty();
             $product = new Product();
             $product->name = $item->getName();
             $product->quantity = $item->getQty();
-            $product->unit_price = $price;
+            $product->unit_price = $item->getPriceInclTax() *100;
             $product->tax_rate = $item->getTaxPercent() *100;
-            $product->total_amount = $lineTotal *100;
+            $product->total_amount = $item->getRowTotalInclTax() *100;
             $product->total_tax_amount = $item->getTaxAmount() *100;
 
             $tax += $product->total_tax_amount;

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -28,20 +28,19 @@
         <policy id="script-src">
             <values>
                 <value id="cko-cdn" type="host">https://cdn.checkout.com</value>
-                <value id="klarna-cdn" type="host">https://x.klarnacdn.net/kp/lib/v1/api.js</value>
+                <value id="klarna-cdn" type="host">*.klarnacdn.net</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
                 <value id="cko-cdn" type="host">https://js.checkout.com</value>
-                <value id="klarna-cdn" type="host">https://eu.playground.klarnaevt.com</value>
+                <value id="klarna-cdn" type="host">*.klarnaevt.com</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
                 <value id="cko-cdn" type="host">https://js.checkout.com</value>
-                <value id="klarna" type="host">https://klarna-payments-eu.playground.klarna.com</value>
-                <value id="klarna-src" type="host">https://js.playground.klarna.com</value>
+                <value id="klarna" type="host">*.klarna.com</value>
             </values>
         </policy>
         <policy id="img-src">

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -41,6 +41,7 @@
             <values>
                 <value id="cko-cdn" type="host">https://js.checkout.com</value>
                 <value id="klarna" type="host">https://klarna-payments-eu.playground.klarna.com</value>
+                <value id="klarna-src" type="host">https://js.playground.klarna.com/</value>
             </values>
         </policy>
         <policy id="img-src">

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -41,7 +41,7 @@
             <values>
                 <value id="cko-cdn" type="host">https://js.checkout.com</value>
                 <value id="klarna" type="host">https://klarna-payments-eu.playground.klarna.com</value>
-                <value id="klarna-src" type="host">https://js.playground.klarna.com/</value>
+                <value id="klarna-src" type="host">https://js.playground.klarna.com</value>
             </values>
         </policy>
         <policy id="img-src">

--- a/view/frontend/templates/payment/apm/klarna.phtml
+++ b/view/frontend/templates/payment/apm/klarna.phtml
@@ -59,6 +59,8 @@
                      * @param      {Array}  methods  The methods
                      */
                     load: function(data, methods) {
+                        console.log(Utilities.formatDecimals(parseFloat(data.quote.grand_total)) *100)
+                        console.log(Utilities.formatDecimals(parseFloat(data.tax_amount)) *100)
                         var self = this;
                         try {
                             Klarna.Payments.init({client_token: data.source.client_token}); // Initialize Klarna

--- a/view/frontend/templates/payment/apm/klarna.phtml
+++ b/view/frontend/templates/payment/apm/klarna.phtml
@@ -60,6 +60,8 @@
                      */
                     load: function(data, methods) {
                         var self = this;
+                        console.log((parseFloat(data.quote.grand_total) * 100).toFixed(0))
+                        console.log((parseFloat(data.tax_amount) * 100).toFixed(0))
                         try {
                             Klarna.Payments.init({client_token: data.source.client_token}); // Initialize Klarna
                             Klarna.Payments.load({

--- a/view/frontend/templates/payment/apm/klarna.phtml
+++ b/view/frontend/templates/payment/apm/klarna.phtml
@@ -59,8 +59,6 @@
                      * @param      {Array}  methods  The methods
                      */
                     load: function(data, methods) {
-                        console.log(Utilities.formatDecimals(parseFloat(data.quote.grand_total)) *100)
-                        console.log(Utilities.formatDecimals(parseFloat(data.tax_amount)) *100)
                         var self = this;
                         try {
                             Klarna.Payments.init({client_token: data.source.client_token}); // Initialize Klarna
@@ -73,8 +71,8 @@
                                 purchase_country:   data.billing.country_id,
                                 purchase_currency:  data.quote.quote_currency_code,
                                 locale:             data.locale,
-                                order_amount:       Utilities.formatDecimals(parseFloat(data.quote.grand_total)) *100,
-                                order_tax_amount:   Utilities.formatDecimals(parseFloat(data.tax_amount)) *100,
+                                order_amount:       (parseFloat(data.quote.grand_total) * 100).toFixed(0),
+                                order_tax_amount:   (parseFloat(data.tax_amount) * 100).toFixed(0),
                                 order_lines:        data.products,
                                 billing_address:    {
                                     given_name:     data.billing.firstname,

--- a/view/frontend/templates/payment/apm/klarna.phtml
+++ b/view/frontend/templates/payment/apm/klarna.phtml
@@ -60,8 +60,6 @@
                      */
                     load: function(data, methods) {
                         var self = this;
-                        console.log((parseFloat(data.quote.grand_total) * 100).toFixed(0))
-                        console.log((parseFloat(data.tax_amount) * 100).toFixed(0))
                         try {
                             Klarna.Payments.init({client_token: data.source.client_token}); // Initialize Klarna
                             Klarna.Payments.load({

--- a/view/frontend/templates/payment/apm/klarna.phtml
+++ b/view/frontend/templates/payment/apm/klarna.phtml
@@ -71,8 +71,8 @@
                                 purchase_country:   data.billing.country_id,
                                 purchase_currency:  data.quote.quote_currency_code,
                                 locale:             data.locale,
-                                order_amount:       parseFloat(data.quote.grand_total) *100,
-                                order_tax_amount:   parseFloat(data.tax_amount) *100,
+                                order_amount:       Utilities.formatDecimals(parseFloat(data.quote.grand_total)) *100,
+                                order_tax_amount:   Utilities.formatDecimals(parseFloat(data.tax_amount)) *100,
                                 order_lines:        data.products,
                                 billing_address:    {
                                     given_name:     data.billing.firstname,

--- a/view/frontend/templates/payment/apm/klarna.phtml
+++ b/view/frontend/templates/payment/apm/klarna.phtml
@@ -71,8 +71,8 @@
                                 purchase_country:   data.billing.country_id,
                                 purchase_currency:  data.quote.quote_currency_code,
                                 locale:             data.locale,
-                                order_amount:       parseInt(data.quote.grand_total) *100,
-                                order_tax_amount:   parseInt(data.tax_amount) *100,
+                                order_amount:       parseFloat(data.quote.grand_total) *100,
+                                order_tax_amount:   parseFloat(data.tax_amount) *100,
                                 order_lines:        data.products,
                                 billing_address:    {
                                     given_name:     data.billing.firstname,

--- a/view/frontend/web/js/view/payment/utilities.js
+++ b/view/frontend/web/js/view/payment/utilities.js
@@ -54,15 +54,6 @@ define(
             },
 
             /**
-             * Format an amount to 2 decimals.
-             *
-             * @return {number}
-             */
-            formatDecimals : function (amount) {
-                return Math.round((amount + "e2") + "e-2")
-            },
-
-            /**
              * Load a CSS file
              *
              * @return {void}

--- a/view/frontend/web/js/view/payment/utilities.js
+++ b/view/frontend/web/js/view/payment/utilities.js
@@ -59,7 +59,7 @@ define(
              * @return {number}
              */
             formatDecimals : function (amount) {
-                return Math.round(amount * 100) / 100;
+                return Math.round((amount + Number.EPSILON) * 100) / 100
             },
 
             /**

--- a/view/frontend/web/js/view/payment/utilities.js
+++ b/view/frontend/web/js/view/payment/utilities.js
@@ -54,6 +54,15 @@ define(
             },
 
             /**
+             * Format an amount to 2 decimals.
+             *
+             * @return {number}
+             */
+            formatDecimals : function (amount) {
+                return Math.round(amount * 100) / 100;
+            },
+
+            /**
              * Load a CSS file
              *
              * @return {void}

--- a/view/frontend/web/js/view/payment/utilities.js
+++ b/view/frontend/web/js/view/payment/utilities.js
@@ -59,7 +59,7 @@ define(
              * @return {number}
              */
             formatDecimals : function (amount) {
-                return Math.round((amount + Number.EPSILON) * 100) / 100
+                return Math.round((amount + "e2") + "e-2")
             },
 
             /**


### PR DESCRIPTION
- The amount we sent to Klarna didn't match the order amount
- The product line items we sent to the gateway didn't match what was previously sent to Klarna
- We can use wildcards for the content security policies

The amounts only matched before when the total was a whole number