### PR TITLE
Ecpint 1799 3DS timeout

### DIFF
--- a/Controller/Payment/Fail.php
+++ b/Controller/Payment/Fail.php
@@ -163,21 +163,15 @@ class Fail extends \Magento\Framework\App\Action\Action
                 }
             }
         } catch (\Checkout\Library\Exceptions\CheckoutHttpException $e) {
-            $order = $this->session->getLastRealOrder();
 
-            if ($order) {
                 // Restore the quote
-                $this->session->restoreQuote();
+            $this->session->restoreQuote();
 
-                $this->messageManager->addErrorMessage(
-                    __('The 3DSecure session expired')
+            $this->messageManager->addErrorMessage(
+                    __('There was an error processing your transaction')
                 );
 
-                // Handle the failed order
-                $this->orderStatusHandler->handleFailedPayment($order);
-
-                return $this->_redirect('checkout/cart', ['_secure' => true]);
-            }
+            return $this->_redirect('checkout/cart', ['_secure' => true]);
         }
     }
 }

--- a/Controller/Payment/Fail.php
+++ b/Controller/Payment/Fail.php
@@ -100,66 +100,83 @@ class Fail extends \Magento\Framework\App\Action\Action
      */
     public function execute()
     {
-        // Get the session id
-        $sessionId = $this->getRequest()->getParam('cko-session-id', null);
-        if ($sessionId) {
-            // Get the store code
-            $storeCode = $this->storeManager->getStore()->getCode();
+        try {
+            // Get the session id
+            $sessionId = $this->getRequest()->getParam('cko-session-id', null);
+            if ($sessionId) {
+                // Get the store code
+                $storeCode = $this->storeManager->getStore()->getCode();
 
-            // Initialize the API handler
-            $api = $this->apiHandler->init($storeCode);
+                // Initialize the API handler
+                $api = $this->apiHandler->init($storeCode);
 
-            // Get the payment details
-            $response = $api->getPaymentDetails($sessionId);
+                // Get the payment details
+                $response = $api->getPaymentDetails($sessionId);
 
-            // Logging
-            $this->logger->display($response);
+                // Logging
+                $this->logger->display($response);
 
-            // Don't restore quote if saved card request
-            if ($response->amount !== 0 && $response->amount !== 100) {
-                // Find the order from increment id
-                $order = $this->orderHandler->getOrder([
-                    'increment_id' => $response->reference
-                ]);
+                // Don't restore quote if saved card request
+                if ($response->amount !== 0 && $response->amount !== 100) {
+                    // Find the order from increment id
+                    $order = $this->orderHandler->getOrder([
+                        'increment_id' => $response->reference
+                    ]);
 
-                // Log the payment error
-                $this->paymentErrorHandlerService->logPaymentError(
-                    $response,
-                    $order
-                );
+                    // Log the payment error
+                    $this->paymentErrorHandlerService->logPaymentError(
+                        $response,
+                        $order
+                    );
 
+                    // Restore the quote
+                    $this->session->restoreQuote();
+
+                    // Handle the failed order
+                    $this->orderStatusHandler->handleFailedPayment($order);
+
+                    $errorMessage = null;
+                    if (isset($response->actions[0]['response_code'])) {
+                        $errorMessage = $this->paymentErrorHandlerService->getErrorMessage(
+                            $response->actions[0]['response_code']
+                        );
+                    }
+
+                    // Display the message
+                    $this->messageManager->addErrorMessage(
+                        $errorMessage ? $errorMessage->render() : __('The transaction could not be processed.')
+                    );
+
+                    // Return to the cart
+                    if (isset($response->metadata['failureUrl'])) {
+                        return $this->_redirect($response->metadata['failureUrl']);
+                    } else {
+                        return $this->_redirect('checkout/cart', ['_secure' => true]);
+                    }
+                } else {
+                    $this->messageManager->addErrorMessage(
+                        __('The card could not be saved.')
+                    );
+
+                    // Return to the saved card page
+                    return $this->_redirect('vault/cards/listaction', ['_secure' => true]);
+                }
+            }
+        } catch (\Checkout\Library\Exceptions\CheckoutHttpException $e) {
+            $order = $this->session->getLastRealOrder();
+
+            if ($order) {
                 // Restore the quote
                 $this->session->restoreQuote();
+
+                $this->messageManager->addErrorMessage(
+                    __('The 3DSecure session expired')
+                );
 
                 // Handle the failed order
                 $this->orderStatusHandler->handleFailedPayment($order);
 
-                $errorMessage = null;
-                if (isset($response->actions[0]['response_code'])) {
-                    $errorMessage = $this->paymentErrorHandlerService->getErrorMessage(
-                        $response->actions[0]['response_code']
-                    );
-                }
-
-                // Display the message
-                $this->messageManager->addErrorMessage(
-                    $errorMessage ? $errorMessage->render() : __('The transaction could not be processed.')
-                );
-
-                // Return to the cart
-                if (isset($response->metadata['failureUrl'])) {
-                    header('Location: ' . $response->metadata['failureUrl']);
-                    exit();
-                } else {
-                    return $this->_redirect('checkout/cart', ['_secure' => true]);    
-                }
-            } else {
-                $this->messageManager->addErrorMessage(
-                    __('The card could not be saved.')
-                );
-
-                // Return to the saved card page
-                return $this->_redirect('vault/cards/listaction', ['_secure' => true]);
+                return $this->_redirect('checkout/cart', ['_secure' => true]);
             }
         }
     }

--- a/Controller/Payment/Fail.php
+++ b/Controller/Payment/Fail.php
@@ -165,13 +165,13 @@ class Fail extends \Magento\Framework\App\Action\Action
         } catch (\Checkout\Library\Exceptions\CheckoutHttpException $e) {
 
                 // Restore the quote
-            $this->session->restoreQuote();
+                $this->session->restoreQuote();
 
-            $this->messageManager->addErrorMessage(
-                    __('There was an error processing your transaction')
+                $this->messageManager->addErrorMessage(
+                    __('The transaction could not be processed.')
                 );
 
-            return $this->_redirect('checkout/cart', ['_secure' => true]);
-        }
+                return $this->_redirect('checkout/cart', ['_secure' => true]);
+            }
     }
 }

--- a/Controller/Payment/Verify.php
+++ b/Controller/Payment/Verify.php
@@ -17,8 +17,6 @@
 
 namespace CheckoutCom\Magento2\Controller\Payment;
 
-use CheckoutCom\Magento2\Model\Service\ShopperHandlerService;
-
 /**
  * Class Verify
  */
@@ -115,9 +113,10 @@ class Verify extends \Magento\Framework\App\Action\Action
 
                 // Get the payment details
                 $response = $api->getPaymentDetails($sessionId);
-                
+
                 // Check for zero dollar auth
                 if ($response->status !== "Card Verified") {
+
                     // Set the method ID
                     $this->methodId = $response->metadata['methodId'];
 
@@ -134,8 +133,7 @@ class Verify extends \Magento\Framework\App\Action\Action
                         // Process the response
                         if ($api->isValidResponse($response)) {
                             if (isset($response->metadata['successUrl']) &&
-                                !str_contains($response->metadata['successUrl'], 'checkout_com/payment/verify'))
-                            {
+                                !str_contains($response->metadata['successUrl'], 'checkout_com/payment/verify')) {
                                 return $this->_redirect($response->metadata['successUrl']);
                             } else {
                                 return $this->_redirect('checkout/onepage/success', ['_secure' => true]);
@@ -150,7 +148,7 @@ class Verify extends \Magento\Framework\App\Action\Action
                             );
                         }
                     } else {
-                        // Add and error message
+                        // Add an error message
                         $this->messageManager->addErrorMessage(
                             __('Invalid request. No order found.')
                         );


### PR DESCRIPTION
In the case of a `payment_expired` webhook arriving while the user is on an incomplete 3DS verification page, successfully redirect back to cart.

Fix: Handle CheckoutHTTPException and redirect to cart when one is caught.