### PR TITLE
Update RefundInvoice.php

### DIFF
--- a/Plugin/Api/RefundInvoice.php
+++ b/Plugin/Api/RefundInvoice.php
@@ -145,7 +145,7 @@ class RefundInvoice
             }
 
             // Set the transaction id from response
-            $payment->setTransactionId($response->action_id);
+            $payment->setTransactionId($response['action_id']);
             $this->orderPaymentRepository->save($payment);
 
             $result = [$creditMemo, $order, $isOnline];


### PR DESCRIPTION
This has been erroring our refunds. 

2023-08-21T16:10:52.681531+00:00] main.CRITICAL: Exception: Warning: Attempt to read property "action_id" on array in /home/cloudpanel/htdocs/www.chemist-4-u.com/releases/2023_08_11_4_18_39_branch_v2.4 .4-61/vendor/checkoutcom/magento2/Plugin/Api/RefundInvoice.php on line 148 in /home/cloudpanel/htdocs/www.chemist-4-u.com/releases/2023_08_11_4_18_39_branch_v2.4.4-61/vendor/magento/framework/App/ErrorH andler.php:61
Stack trace:
#0 /home/cloudpanel/htdocs/www.chemist-4-u.com/releases/2023_08_11_4_18_39_branch_v2.4.4-61/vendor/checkoutcom/magento2/Plugin/Api/RefundInvoice.php(148): Magento\Framework\App\ErrorHandler->handler() #1 /home/cloudpanel/htdocs/www.chemist-4-u.com/releases/2023_08_11_4_18_39_branch_v2.4.4-61/vendor/magento/framework/Interception/Interceptor.php(121): CheckoutCom\Magento2\Plugin\Api\RefundInvoice->bef oreRefund()
#2 /home/cloudpanel/htdocs/www.chemist-4-u.com/releases/2023_08_11_4_18_39_branch_v2.4.4-61/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Sales\Model\Order\RefundAdapter\Intercepto r->Magento\Framework\Interception\{closure}()
#3 /home/cloudpanel/htdocs/www.chemist-4-u.co

You refactored to using an array, not an object.