### PR TITLE
fix:discount coupon code not reflected if added in payment step

### DIFF
--- a/view/frontend/web/js/flow/view/payment/checkoutcom_flow.js
+++ b/view/frontend/web/js/flow/view/payment/checkoutcom_flow.js
@@ -104,6 +104,12 @@ define(
                             this.reloadFlow();
                         }
                     });
+
+                    Quote.totals.subscribe(() => {
+                        if (Utilities.methodIsSelected(METHOD_ID)) {
+                            this.reloadFlow();
+                        }
+                    });
                 },
 
                 /**
@@ -120,7 +126,9 @@ define(
                     this.setCountryCode();
                     this.sendSaveCardEvent();
 
-                    this.flowComponent.unmount();
+                    if (this.flowComponent) {
+                        this.flowComponent.unmount();
+                    }
 
                     this.getFlowContextData();
                 },


### PR DESCRIPTION
**Problem**
When a customer applies or removes a discount code during the Payment step of the checkout flow, the Checkout.com payment request does not reflect the updated order total.

This occurs because the payment object/payload is initialized when the user first lands on the payment step. Since applying a coupon in Magento's standard checkout doesn't always trigger a full re-initialization of the payment component's internal data, the extension continues to pass the original amount (pre-discount) to the Checkout.com API. This results in the customer being charged the full price despite a coupon being successfully applied to the Magento quote.

**Solution**
I have updated the logic to ensure that the payment totals are recalculated/refreshed whenever the quote's "totals" object is updated. This ensures that the final payload sent to Checkout.com always contains the most recent grand_total including any discounts applied at the last minute.

**Changes**

1. Added a subscriber/trigger to watch for totals changes during the payment step.
2. Forced a refresh of the payment amount calculation before the transaction is initialized.

**How to Test**

1. Add products to the cart and proceed to Checkout.
2. Navigate to the Payment step without applying a coupon first.
3. Observe the "Order Summary" total.
4. Apply a valid discount code in the "Apply Discount Code" section.
5. Verify that the Checkout.com payment request now uses the discounted amount instead of the original amount.