### PR TITLE
Use null (not 0) for guest quote customer_id to match Magento core convention

### DIFF
--- a/Model/Service/QuoteHandlerService.php
+++ b/Model/Service/QuoteHandlerService.php
@@ -224,7 +224,7 @@ class QuoteHandlerService
         $guestEmail = ($email) ? $email : $this->findEmail($quote);
 
         // Set the quote as guest
-        $quote->setCustomerId(0)->setCustomerEmail($guestEmail)->setCustomerIsGuest(true)->setCustomerGroupId(
+        $quote->setCustomerId(null)->setCustomerEmail($guestEmail)->setCustomerIsGuest(true)->setCustomerGroupId(
             GroupInterface::NOT_LOGGED_IN_ID
         );
 


### PR DESCRIPTION
## Summary
`Model/Service/QuoteHandlerService::prepareGuestQuote()` currently initialises the guest quote with `setCustomerId(0)`. This PR changes that to `setCustomerId(null)` to align with Magento's own schema and the convention used by `Magento\Quote\Model\Quote` for guest carts.

Single-line change in one file. No schema migration, no API change, no behavioural regression in existing flows.

## Problem
For guest checkouts the plugin writes `customer_id = 0` to the quote:

```php
$quote->setCustomerId(0)
    ->setCustomerEmail($guestEmail)
    ->setCustomerIsGuest(true)
    ->setCustomerGroupId(GroupInterface::NOT_LOGGED_IN_ID);