### PR TITLE
[FIX] Replace showMessage with Utilities.showMessage

### DIFF
--- a/view/frontend/web/js/flow/view/payment/checkoutcom_flow.js
+++ b/view/frontend/web/js/flow/view/payment/checkoutcom_flow.js
@@ -632,7 +632,7 @@ define(
                             if (!orderResponse || !orderResponse.success) {
                                 FullScreenLoader.stopLoader();
                                 if (orderResponse && orderResponse.message) {
-                                    self.showMessage('error', orderResponse.message, METHOD_ID);
+                                    Utilities.showMessage('error', orderResponse.message, METHOD_ID);
                                 }
                                 return Promise.reject(orderResponse || new Error('Place order failed'));
                             }


### PR DESCRIPTION
issue because showMessage not defined in same js
TypeError: self.showMessage is not a function
    at Object.<anonymous> (VM16839 checkoutcom_flow.min.js:22:284)